### PR TITLE
changed header guards so they are standard conforming C

### DIFF
--- a/json.h
+++ b/json.h
@@ -23,8 +23,8 @@
 //
 // For more information, please refer to <http://unlicense.org/>
 
-#ifndef __JSON_H__
-#define __JSON_H__
+#ifndef SHEREDOM_JSON_H_INCLUDED
+#define SHEREDOM_JSON_H_INCLUDED
 
 #include <stddef.h>
 #include <stdlib.h>
@@ -131,4 +131,4 @@ struct json_value_s {
 #pragma warning(pop)
 #endif
 
-#endif//__JSON_H__
+#endif//SHEREDOM_JSON_H_INCLUDED


### PR DESCRIPTION
Hi, names starting with double underscores are reserved for the implementation. You shouldn't use them in your code (unless you happen to be a compiler vendor). This change makes the code more portable & future proof. See: https://www.gnu.org/software/libc/manual/html_node/Reserved-Names.html 