### PR TITLE
Basic error reporting

### DIFF
--- a/json.c
+++ b/json.c
@@ -40,6 +40,9 @@ struct json_parse_state_s {
   const char* src;
   size_t size;
   size_t offset;
+  size_t line_no;            // line counter for error reporting
+  size_t line_offset;        // (offset-line_offset) is the character number (in bytes)
+  enum json_parse_error_e error;
   char* dom;
   char* data;
   size_t dom_size;
@@ -61,8 +64,11 @@ static int json_skip_whitespace(struct json_parse_state_s* state) {
     default:
       state->offset = offset;
       return 0;
-    case ' ':
     case '\n':
+	  state->line_no++;
+	  state->line_offset = offset;
+      break;
+    case ' ':
     case '\r':
     case '\t':
       break;
@@ -81,7 +87,7 @@ static int json_get_string_size(struct json_parse_state_s* state) {
   state->dom_size += sizeof(struct json_string_s);
 
   if ('"' != state->src[state->offset]) {
-    // expected string to begin with '"'!
+	state->error = json_parse_error_expected_opening_quote;
     return 1;
   }
 
@@ -100,7 +106,7 @@ static int json_get_string_size(struct json_parse_state_s* state) {
 
       switch (state->src[state->offset]) {
       default:
-        // invalid escaped sequence in string!
+		state->error = json_parse_error_invalid_string_escape_sequence;
         return 1;
       case '"':
       case '\\':
@@ -116,6 +122,7 @@ static int json_get_string_size(struct json_parse_state_s* state) {
       case 'u':
         if (state->offset + 5 < state->size) {
           // invalid escaped unicode sequence!
+		  state->error = json_parse_error_invalid_string_escape_sequence;
           return 1;
         } else if (
           !json_is_hexadecimal_digit(state->src[state->offset + 1]) ||
@@ -123,6 +130,7 @@ static int json_get_string_size(struct json_parse_state_s* state) {
           !json_is_hexadecimal_digit(state->src[state->offset + 3]) ||
           !json_is_hexadecimal_digit(state->src[state->offset + 4])) {
           // escaped unicode sequences must contain 4 hexadecimal digits!
+          state->error = json_parse_error_invalid_string_escape_sequence;
           return 1;
         }
 
@@ -149,7 +157,7 @@ static int json_get_object_size(struct json_parse_state_s* state) {
   int allow_comma = 0;
 
   if ('{' != state->src[state->offset]) {
-    // expected object to begin with leading '{'
+	state->error = json_parse_error_unknown;
     return 1;
   }
 
@@ -160,7 +168,7 @@ static int json_get_object_size(struct json_parse_state_s* state) {
 
   while (state->offset < state->size) {
     if (json_skip_whitespace(state)) {
-      // reached end of buffer before object was complete!
+      state->error = json_parse_error_premature_end_of_buffer;
       return 1;
     }
 
@@ -175,7 +183,7 @@ static int json_get_object_size(struct json_parse_state_s* state) {
     // if we parsed at least once element previously, grok for a comma
     if (allow_comma) {
       if (',' != state->src[state->offset]) {
-        // expected a comma where there was none!
+		state->error = json_parse_error_expected_comma;
         return 1;
       }
 
@@ -191,12 +199,12 @@ static int json_get_object_size(struct json_parse_state_s* state) {
     }
 
     if (json_skip_whitespace(state)) {
-      // reached end of buffer before object was complete!
+      state->error = json_parse_error_premature_end_of_buffer;
       return 1;
     }
 
     if (':' != state->src[state->offset]) {
-      // colon seperating name/value pair was missing!
+      state->error = json_parse_error_expected_colon;
       return 1;
     }
 
@@ -204,7 +212,7 @@ static int json_get_object_size(struct json_parse_state_s* state) {
     state->offset++;
 
     if (json_skip_whitespace(state)) {
-      // reached end of buffer before object was complete!
+      state->error = json_parse_error_premature_end_of_buffer;
       return 1;
     }
 
@@ -230,7 +238,8 @@ static int json_get_array_size(struct json_parse_state_s* state) {
   int allow_comma = 0;
 
   if ('[' != state->src[state->offset]) {
-    // expected array to begin with leading '['
+	// expected array to begin with leading '['
+	state->error = json_parse_error_unknown;
     return 1;
   }
 
@@ -241,7 +250,7 @@ static int json_get_array_size(struct json_parse_state_s* state) {
 
   while (state->offset < state->size) {
     if (json_skip_whitespace(state)) {
-      // reached end of buffer before array was complete!
+      state->error = json_parse_error_premature_end_of_buffer;
       return 1;
     }
 
@@ -256,7 +265,7 @@ static int json_get_array_size(struct json_parse_state_s* state) {
     // if we parsed at least once element previously, grok for a comma
     if (allow_comma) {
       if (',' != state->src[state->offset]) {
-        // expected a comma where there was none!
+        state->error = json_parse_error_expected_comma;
         return 1;
       }
 
@@ -299,6 +308,7 @@ static int json_get_number_size(struct json_parse_state_s* state) {
     if ((state->offset < state->size) &&
       ('0' <= state->src[state->offset] && state->src[state->offset] <= '9')) {
       // a leading '0' must not be immediately followed by any digits!
+	  state->error = json_parse_error_invalid_number_format;
       return 1;
     }
   }
@@ -349,7 +359,7 @@ static int json_get_number_size(struct json_parse_state_s* state) {
 
 static int json_get_value_size(struct json_parse_state_s* state) {
   if (json_skip_whitespace(state)) {
-    // consumed the whole buffer when we expected a value!
+	state->error = json_parse_error_premature_end_of_buffer;
     return 1;
   }
 
@@ -400,6 +410,7 @@ static int json_get_value_size(struct json_parse_state_s* state) {
     }
 
     // invalid value!
+	state->error = json_parse_error_invalid_value;
     return 1;
   }
 }
@@ -787,9 +798,16 @@ static int json_parse_value(struct json_parse_state_s* state,
   }
 }
 
-struct json_value_s* json_parse(const void* src, size_t src_size) {
+struct json_value_s* json_parse_ex(const void* src, size_t src_size, struct json_parse_result_s* result) {
   struct json_parse_state_s state;
   void* allocation;
+
+  if (result) {
+	result->error = json_parse_error_none;
+	result->error_offset = 0;
+	result->error_line_no = 0;
+	result->error_row_no = 0;
+  }
 
   if (0 == src || 2 > src_size) {
     // absolute minimum valid json is either "{}" or "[]"
@@ -799,11 +817,20 @@ struct json_value_s* json_parse(const void* src, size_t src_size) {
   state.src = src;
   state.size = src_size;
   state.offset = 0;
+  state.line_no = 1;
+  state.line_offset = 0;
+  state.error = json_parse_error_none;
   state.dom_size = 0;
   state.data_size = 0;
 
   if (json_get_value_size(&state)) {
     // parsing value's size failed (most likely an invalid JSON DOM!)
+	if (result) {
+	  result->error = state.error;
+	  result->error_offset = state.offset;
+	  result->error_line_no = state.line_no;
+	  result->error_row_no = state.offset - state.line_offset;
+	}
     return 0;
   }
 
@@ -832,6 +859,10 @@ struct json_value_s* json_parse(const void* src, size_t src_size) {
   }
 
   return allocation;
+}
+
+struct json_value_s* json_parse(const void* src, size_t src_size) {
+  return json_parse_ex(src, src_size, NULL);
 }
 
 static int json_write_minified_get_value_size(const struct json_value_s* value, size_t* size);

--- a/json.c
+++ b/json.c
@@ -146,6 +146,7 @@ static int json_get_string_size(struct json_parse_state_s* state) {
 
 static int json_get_object_size(struct json_parse_state_s* state) {
   size_t elements = 0;
+  int allow_comma = 0;
 
   if ('{' != state->src[state->offset]) {
     // expected object to begin with leading '{'
@@ -172,7 +173,7 @@ static int json_get_object_size(struct json_parse_state_s* state) {
     }
 
     // if we parsed at least once element previously, grok for a comma
-    if (0 < elements) {
+    if (allow_comma) {
       if (',' != state->src[state->offset]) {
         // expected a comma where there was none!
         return 1;
@@ -180,11 +181,8 @@ static int json_get_object_size(struct json_parse_state_s* state) {
 
       // skip comma
       state->offset++;
-
-      if (json_skip_whitespace(state)) {
-        // reached end of buffer before object was complete!
-        return 1;
-      }
+	  allow_comma = 0;
+      continue;
     }
 
     if (json_get_string_size(state)) {
@@ -217,6 +215,7 @@ static int json_get_object_size(struct json_parse_state_s* state) {
 
     // successfully parsed a name/value pair!
     elements++;
+	allow_comma = 1;
   }
 
   state->dom_size += sizeof(struct json_string_s) * elements;
@@ -228,6 +227,7 @@ static int json_get_object_size(struct json_parse_state_s* state) {
 
 static int json_get_array_size(struct json_parse_state_s* state) {
   size_t elements = 0;
+  int allow_comma = 0;
 
   if ('[' != state->src[state->offset]) {
     // expected array to begin with leading '['
@@ -254,7 +254,7 @@ static int json_get_array_size(struct json_parse_state_s* state) {
     }
 
     // if we parsed at least once element previously, grok for a comma
-    if (0 < elements) {
+    if (allow_comma) {
       if (',' != state->src[state->offset]) {
         // expected a comma where there was none!
         return 1;
@@ -262,11 +262,8 @@ static int json_get_array_size(struct json_parse_state_s* state) {
 
       // skip comma
       state->offset++;
-
-      if (json_skip_whitespace(state)) {
-        // reached end of buffer before array was complete!
-        return 1;
-      }
+	  allow_comma = 0;
+      continue;
     }
 
     if (json_get_value_size(state)) {
@@ -276,6 +273,7 @@ static int json_get_array_size(struct json_parse_state_s* state) {
 
     // successfully parsed an array element!
     elements++;
+	allow_comma = 1;
   }
 
   state->dom_size += sizeof(struct json_value_s) * elements;
@@ -448,6 +446,7 @@ static int json_parse_string(struct json_parse_state_s* state,
 static int json_parse_object(struct json_parse_state_s* state,
   struct json_object_s* object) {
   size_t elements = 0;
+  int allow_comma = 0;
   struct json_object_element_s* previous = 0;
 
   if ('{' != state->src[state->offset]) {
@@ -491,7 +490,7 @@ static int json_parse_object(struct json_parse_state_s* state,
     }
 
     // if we parsed at least one element previously, grok for a comma
-    if (0 < elements) {
+    if (allow_comma) {
       if (',' != state->src[state->offset]) {
         // expected a comma where there was none!
         return 1;
@@ -499,11 +498,8 @@ static int json_parse_object(struct json_parse_state_s* state,
 
       // skip comma
       state->offset++;
-
-      if (json_skip_whitespace(state)) {
-        // reached end of buffer before object was complete!
-        return 1;
-      }
+	  allow_comma = 0;
+      continue;
     }
 
     element = (struct json_object_element_s* )state->dom;
@@ -561,6 +557,7 @@ static int json_parse_object(struct json_parse_state_s* state,
 
     // successfully parsed a name/value pair!
     elements++;
+	allow_comma = 1;
   }
 
   // if we had at least one element, end the linked list
@@ -580,6 +577,7 @@ static int json_parse_object(struct json_parse_state_s* state,
 static int json_parse_array(struct json_parse_state_s* state,
   struct json_array_s* array) {
   size_t elements = 0;
+  int allow_comma = 0;
   struct json_array_element_s* previous = 0;
 
   if ('[' != state->src[state->offset]) {
@@ -616,7 +614,7 @@ static int json_parse_array(struct json_parse_state_s* state,
     }
 
     // if we parsed at least one element previously, grok for a comma
-    if (0 < elements) {
+    if (allow_comma) {
       if (',' != state->src[state->offset]) {
         // expected a comma where there was none!
         return 1;
@@ -624,11 +622,8 @@ static int json_parse_array(struct json_parse_state_s* state,
 
       // skip comma
       state->offset++;
-
-      if (json_skip_whitespace(state)) {
-        // reached end of buffer before array was complete!
-        return 1;
-      }
+	  allow_comma = 0;
+      continue;
     }
 
     element = (struct json_array_element_s* )state->dom;
@@ -657,6 +652,7 @@ static int json_parse_array(struct json_parse_state_s* state,
 
     // successfully parsed an array element!
     elements++;
+	allow_comma = 1;
   }
 
   // end the linked list

--- a/json.h
+++ b/json.h
@@ -161,11 +161,11 @@ struct json_parse_result_s {
   // the error code
   enum json_parse_error_e error;
   // the character offset for the error in the JSON input
-  int error_offset;
+  size_t error_offset;
   // the line number for the error in the JSON input
-  int error_line_no;
+  size_t error_line_no;
   // the row number for the error, in bytes
-  int error_row_no;
+  size_t error_row_no;
 };
 
 #ifdef __cplusplus

--- a/json.h
+++ b/json.h
@@ -39,12 +39,16 @@ extern "C" {
 #endif
 
 struct json_value_s;
+struct json_parse_result_s;
 
 // Parse a JSON text file, returning a pointer to the root of the JSON
 // structure. json_parse performs 1 call to malloc for the entire encoding.
 // Returns 0 if an error occurred (malformed JSON input, or malloc failed)
 struct json_value_s* json_parse(
   const void* src, size_t src_size);
+
+struct json_value_s* json_parse_ex(
+  const void* src, size_t src_size, struct json_parse_result_s* result);
 
 // Write out a minified JSON utf-8 string. This string is an encoding of the
 // minimal string characters required to still encode the same data.
@@ -137,6 +141,31 @@ struct json_value_s {
   // Must be one of json_type_e. If type is json_type_true, json_type_false, or
   // json_type_null, payload will be NULL
   size_t type;
+};
+
+// a parsing error code
+enum json_parse_error_e {
+  json_parse_error_none = 0,
+  json_parse_error_expected_comma,                  // expected a comma where there was none!
+  json_parse_error_expected_colon,					// colon separating name/value pair was missing!
+  json_parse_error_expected_opening_quote,	        // expected string to begin with '"'!
+  json_parse_error_invalid_string_escape_sequence,	// invalid escaped sequence in string!
+  json_parse_error_invalid_number_format,           // invalid number format!
+  json_parse_error_invalid_value,                   // invalid value!
+  json_parse_error_premature_end_of_buffer,         // reached end of buffer before object/array was complete!
+  json_parse_error_unknown,
+};
+
+// error report from json_parse_ex()
+struct json_parse_result_s {
+  // the error code
+  enum json_parse_error_e error;
+  // the character offset for the error in the JSON input
+  int error_offset;
+  // the line number for the error in the JSON input
+  int error_line_no;
+  // the row number for the error, in bytes
+  int error_row_no;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
PR for #5
NB: this include the PR https://github.com/sheredom/json.h/pull/6 (github-foo lacking)

It is rather basic error reporting. Didn't thoroughly test and I expect some janitorial work, perhaps merge the entry points and bits of commenting. Alloc errors and errors in the second pass (which should be bugs of the library and not data/user error?) aren't reported.

I am not really sure the error code are needed and how they might evolve or be future-proof, haven't put much though into that. The biggest benefit is providing an offset, line number and row.

I haven't measured the overhead but I assume it to be very minor.
