### PR TITLE
Add entry points and parsing support for simplified JSON

### DIFF
--- a/json.c
+++ b/json.c
@@ -40,19 +40,25 @@ struct json_parse_state_s {
   const char* src;
   size_t size;
   size_t offset;
-  size_t line_no;            // line counter for error reporting
-  size_t line_offset;        // (offset-line_offset) is the character number (in bytes)
+  size_t line_no;  // line counter for error reporting
+  size_t
+      line_offset;  // (offset-line_offset) is the character number (in bytes)
   size_t error;
   char* dom;
   char* data;
   size_t dom_size;
   size_t data_size;
+  size_t parsing_simplfied;
 };
 
 static int json_is_hexadecimal_digit(const char c) {
-  return (('0' <= c && c <= '9') ||
-    ('a' <= c && c <= 'f') ||
-    ('A' <= c && c <= 'F'));
+  return (('0' <= c && c <= '9') || ('a' <= c && c <= 'f') ||
+          ('A' <= c && c <= 'F'));
+}
+
+static int json_is_allowed_id_char(const char c) {
+  return (('0' <= c && c <= '9') || ('a' <= c && c <= 'z') ||
+          ('A' <= c && c <= 'Z') || ('_' == c));
 }
 
 static int json_skip_whitespace(struct json_parse_state_s* state) {
@@ -61,17 +67,17 @@ static int json_skip_whitespace(struct json_parse_state_s* state) {
 
   for (offset = state->offset, size = state->size; offset < size; offset++) {
     switch (state->src[offset]) {
-    default:
-      state->offset = offset;
-      return 0;
-    case '\n':
-	  state->line_no++;
-	  state->line_offset = offset;
-      break;
-    case ' ':
-    case '\r':
-    case '\t':
-      break;
+      default:
+        state->offset = offset;
+        return 0;
+      case '\n':
+        state->line_no++;
+        state->line_offset = offset;
+        break;
+      case ' ':
+      case '\r':
+      case '\t':
+        break;
     }
   }
 
@@ -87,7 +93,7 @@ static int json_get_string_size(struct json_parse_state_s* state) {
   state->dom_size += sizeof(struct json_string_s);
 
   if ('"' != state->src[state->offset]) {
-	state->error = json_parse_error_expected_opening_quote;
+    state->error = json_parse_error_expected_opening_quote;
     return 1;
   }
 
@@ -105,38 +111,41 @@ static int json_get_string_size(struct json_parse_state_s* state) {
       }
 
       switch (state->src[state->offset]) {
-      default:
-		state->error = json_parse_error_invalid_string_escape_sequence;
-        return 1;
-      case '"':
-      case '\\':
-      case '/':
-      case 'b':
-      case 'f':
-      case 'n':
-      case 'r':
-      case 't':
-        // all valid characters!
-        state->offset++;
-        break;
-      case 'u':
-        if (state->offset + 5 < state->size) {
-          // invalid escaped unicode sequence!
-		  state->error = json_parse_error_invalid_string_escape_sequence;
-          return 1;
-        } else if (
-          !json_is_hexadecimal_digit(state->src[state->offset + 1]) ||
-          !json_is_hexadecimal_digit(state->src[state->offset + 2]) ||
-          !json_is_hexadecimal_digit(state->src[state->offset + 3]) ||
-          !json_is_hexadecimal_digit(state->src[state->offset + 4])) {
-          // escaped unicode sequences must contain 4 hexadecimal digits!
+        default:
           state->error = json_parse_error_invalid_string_escape_sequence;
           return 1;
-        }
+        case '"':
+        case '\\':
+        case '/':
+        case 'b':
+        case 'f':
+        case 'n':
+        case 'r':
+        case 't':
+          // all valid characters!
+          state->offset++;
+          break;
+        case 'u':
+          if (state->offset + 5 < state->size) {
+            // invalid escaped unicode sequence!
+            state->error = json_parse_error_invalid_string_escape_sequence;
+            return 1;
+          } else if (!json_is_hexadecimal_digit(
+                         state->src[state->offset + 1]) ||
+                     !json_is_hexadecimal_digit(
+                         state->src[state->offset + 2]) ||
+                     !json_is_hexadecimal_digit(
+                         state->src[state->offset + 3]) ||
+                     !json_is_hexadecimal_digit(
+                         state->src[state->offset + 4])) {
+            // escaped unicode sequences must contain 4 hexadecimal digits!
+            state->error = json_parse_error_invalid_string_escape_sequence;
+            return 1;
+          }
 
-        // valid sequence!
-        state->offset += 5;
-        break;
+          // valid sequence!
+          state->offset += 5;
+          break;
       }
     } else {
       // skip character (valid part of sequence)
@@ -152,48 +161,83 @@ static int json_get_string_size(struct json_parse_state_s* state) {
   return 0;
 }
 
-static int json_get_object_size(struct json_parse_state_s* state) {
+static int json_get_id_size(struct json_parse_state_s* state) {
+  if ('"' == state->src[state->offset]) {
+    return json_get_string_size(state);
+  } else if (state->parsing_simplfied) {
+    // in simplified json, ID's don't have to be quoted. We'll still store them
+    // into a json_string_s though
+    state->dom_size += sizeof(struct json_string_s);
+
+    while (state->offset < state->size &&
+        json_is_allowed_id_char(state->src[state->offset])) {
+
+      state->data_size++;
+    }
+
+    // add space for null terminator
+    state->data_size++;
+
+    return 0;
+  } else {
+    state->error = json_parse_error_expected_identifier;
+    return 1;
+  }
+}
+
+static int json_get_object_size(struct json_parse_state_s* state,
+                                int ignore_brackets) {
   size_t elements = 0;
   int allow_comma = 0;
 
-  if ('{' != state->src[state->offset]) {
-	state->error = json_parse_error_unknown;
-    return 1;
-  }
+  if (!ignore_brackets) {
+    if ('{' != state->src[state->offset]) {
+      state->error = json_parse_error_unknown;
+      return 1;
+    }
 
-  // skip leading '{'
-  state->offset++;
+    // skip leading '{'
+    state->offset++;
+  }
 
   state->dom_size += sizeof(struct json_object_s);
 
   while (state->offset < state->size) {
-    if (json_skip_whitespace(state)) {
-      state->error = json_parse_error_premature_end_of_buffer;
-      return 1;
-    }
+    if (ignore_brackets) {
+      if (json_skip_whitespace(state)) {
+        // if we are ignoring brackets, the end of the input string signifies
+        // that we have ended our object!
+        break;
+      }
+    } else {
+      if (json_skip_whitespace(state)) {
+        state->error = json_parse_error_premature_end_of_buffer;
+        return 1;
+      }
 
-    if ('}' == state->src[state->offset]) {
-      // skip trailing '}'
-      state->offset++;
+      if ('}' == state->src[state->offset]) {
+        // skip trailing '}'
+        state->offset++;
 
-      // finished the object!
-      break;
+        // finished the object!
+        break;
+      }
     }
 
     // if we parsed at least once element previously, grok for a comma
     if (allow_comma) {
       if (',' != state->src[state->offset]) {
-		state->error = json_parse_error_expected_comma;
+        state->error = json_parse_error_expected_comma;
         return 1;
       }
 
       // skip comma
       state->offset++;
-	  allow_comma = 0;
+      allow_comma = 0;
       continue;
     }
 
-    if (json_get_string_size(state)) {
+    if (json_get_id_size(state)) {
       // string parsing failed!
       return 1;
     }
@@ -223,7 +267,7 @@ static int json_get_object_size(struct json_parse_state_s* state) {
 
     // successfully parsed a name/value pair!
     elements++;
-	allow_comma = 1;
+    allow_comma = 1;
   }
 
   state->dom_size += sizeof(struct json_string_s) * elements;
@@ -238,8 +282,8 @@ static int json_get_array_size(struct json_parse_state_s* state) {
   int allow_comma = 0;
 
   if ('[' != state->src[state->offset]) {
-	// expected array to begin with leading '['
-	state->error = json_parse_error_unknown;
+    // expected array to begin with leading '['
+    state->error = json_parse_error_unknown;
     return 1;
   }
 
@@ -271,7 +315,7 @@ static int json_get_array_size(struct json_parse_state_s* state) {
 
       // skip comma
       state->offset++;
-	  allow_comma = 0;
+      allow_comma = 0;
       continue;
     }
 
@@ -282,7 +326,7 @@ static int json_get_array_size(struct json_parse_state_s* state) {
 
     // successfully parsed an array element!
     elements++;
-	allow_comma = 1;
+    allow_comma = 1;
   }
 
   state->dom_size += sizeof(struct json_value_s) * elements;
@@ -305,18 +349,18 @@ static int json_get_number_size(struct json_parse_state_s* state) {
     // skip valid '0'
     state->offset++;
 
-    if ((state->offset < state->size) &&
-      ('0' <= state->src[state->offset] && state->src[state->offset] <= '9')) {
+    if ((state->offset < state->size) && ('0' <= state->src[state->offset] &&
+                                          state->src[state->offset] <= '9')) {
       // a leading '0' must not be immediately followed by any digits!
-	  state->error = json_parse_error_invalid_number_format;
+      state->error = json_parse_error_invalid_number_format;
       return 1;
     }
   }
 
   // the main digits of our number next
-  while ((state->offset < state->size) &&
-   ('0' <= state->src[state->offset] && state->src[state->offset] <= '9')) {
-     state->offset++;
+  while ((state->offset < state->size) && ('0' <= state->src[state->offset] &&
+                                           state->src[state->offset] <= '9')) {
+    state->offset++;
   }
 
   if ((state->offset < state->size) && ('.' == state->src[state->offset])) {
@@ -324,28 +368,30 @@ static int json_get_number_size(struct json_parse_state_s* state) {
 
     // a decimal point can be followed by more digits of course!
     while ((state->offset < state->size) &&
-     ('0' <= state->src[state->offset] && state->src[state->offset] <= '9')) {
-       state->offset++;
+           ('0' <= state->src[state->offset] &&
+            state->src[state->offset] <= '9')) {
+      state->offset++;
     }
   }
 
-  if ((state->offset < state->size) && ('e' == state->src[state->offset] ||
-    'E' == state->src[state->offset])) {
+  if ((state->offset < state->size) &&
+      ('e' == state->src[state->offset] || 'E' == state->src[state->offset])) {
     // our number has an exponent!
 
     // skip 'e' or 'E'
     state->offset++;
 
     if ((state->offset < state->size) && ('-' == state->src[state->offset] ||
-      '+' == state->src[state->offset])) {
+                                          '+' == state->src[state->offset])) {
       // skip optional '-' or '+'
       state->offset++;
     }
 
     // consume exponent digits
     while ((state->offset < state->size) &&
-     ('0' <= state->src[state->offset] && state->src[state->offset] <= '9')) {
-       state->offset++;
+           ('0' <= state->src[state->offset] &&
+            state->src[state->offset] <= '9')) {
+      state->offset++;
     }
   }
 
@@ -359,67 +405,67 @@ static int json_get_number_size(struct json_parse_state_s* state) {
 
 static int json_get_value_size(struct json_parse_state_s* state) {
   if (json_skip_whitespace(state)) {
-	state->error = json_parse_error_premature_end_of_buffer;
+    state->error = json_parse_error_premature_end_of_buffer;
     return 1;
   }
 
   state->dom_size += sizeof(struct json_value_s);
 
   switch (state->src[state->offset]) {
-  case '"':
-    return json_get_string_size(state);
-  case '{':
-    return json_get_object_size(state);
-  case '[':
-    return json_get_array_size(state);
-  case '-':
-  case '0':
-  case '1':
-  case '2':
-  case '3':
-  case '4':
-  case '5':
-  case '6':
-  case '7':
-  case '8':
-  case '9':
-    return json_get_number_size(state);
-  default:
-    if ((state->offset + 4) < state->size &&
-      't' == state->src[state->offset + 0] &&
-      'r' == state->src[state->offset + 1] &&
-      'u' == state->src[state->offset + 2] &&
-      'e' == state->src[state->offset + 3]) {
-      state->offset += 4;
-      return 0;
-    } else if ((state->offset + 5) < state->size &&
-      'f' == state->src[state->offset + 0] &&
-      'a' == state->src[state->offset + 1] &&
-      'l' == state->src[state->offset + 2] &&
-      's' == state->src[state->offset + 3] &&
-      'e' == state->src[state->offset + 4]) {
-      state->offset += 5;
-      return 0;
-    } else if ((state->offset + 4) < state->size &&
-      'n' == state->src[state->offset + 0] &&
-      'u' == state->src[state->offset + 1] &&
-      'l' == state->src[state->offset + 2] &&
-      'l' == state->src[state->offset + 3]) {
-      state->offset += 4;
-      return 0;
-    }
+    case '"':
+      return json_get_string_size(state);
+    case '{':
+      return json_get_object_size(state, 0);
+    case '[':
+      return json_get_array_size(state);
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+      return json_get_number_size(state);
+    default:
+      if ((state->offset + 4) < state->size &&
+          't' == state->src[state->offset + 0] &&
+          'r' == state->src[state->offset + 1] &&
+          'u' == state->src[state->offset + 2] &&
+          'e' == state->src[state->offset + 3]) {
+        state->offset += 4;
+        return 0;
+      } else if ((state->offset + 5) < state->size &&
+                 'f' == state->src[state->offset + 0] &&
+                 'a' == state->src[state->offset + 1] &&
+                 'l' == state->src[state->offset + 2] &&
+                 's' == state->src[state->offset + 3] &&
+                 'e' == state->src[state->offset + 4]) {
+        state->offset += 5;
+        return 0;
+      } else if ((state->offset + 4) < state->size &&
+                 'n' == state->src[state->offset + 0] &&
+                 'u' == state->src[state->offset + 1] &&
+                 'l' == state->src[state->offset + 2] &&
+                 'l' == state->src[state->offset + 3]) {
+        state->offset += 4;
+        return 0;
+      }
 
-    // invalid value!
-	state->error = json_parse_error_invalid_value;
-    return 1;
+      // invalid value!
+      state->error = json_parse_error_invalid_value;
+      return 1;
   }
 }
 
 static int json_parse_value(struct json_parse_state_s* state,
-  struct json_value_s* value);
+                            struct json_value_s* value);
 
 static int json_parse_string(struct json_parse_state_s* state,
-  struct json_string_s* string) {
+                             struct json_string_s* string) {
   size_t size = 0;
 
   string->string = state->data;
@@ -433,9 +479,9 @@ static int json_parse_string(struct json_parse_state_s* state,
   state->offset++;
 
   while (state->offset < state->size &&
-    ('"' != state->src[state->offset] ||
-    ('\\' == state->src[state->offset - 1] &&
-    '"' == state->src[state->offset]))) {
+         ('"' != state->src[state->offset] ||
+          ('\\' == state->src[state->offset - 1] &&
+           '"' == state->src[state->offset]))) {
     state->data[size++] = state->src[state->offset++];
   }
 
@@ -454,50 +500,84 @@ static int json_parse_string(struct json_parse_state_s* state,
   return 0;
 }
 
+static int json_parse_id(struct json_parse_state_s* state,
+                         struct json_string_s* string) {
+  if ('"' == state->src[state->offset]) {
+    return json_parse_string(state, string);
+  } else {
+    // otherwise we are parsing a simplified json identifier
+    size_t size = 0;
+
+    string->string = state->data;
+
+    while (json_is_allowed_id_char(state->src[state->offset])) {
+      state->data[size++] = state->src[state->offset++];
+    }
+
+    // record the size of the string
+    string->string_size = size;
+
+    // add null terminator to string
+    state->data[size++] = '\0';
+
+    // move data along
+    state->data += size;
+
+    return 0;
+  }
+}
+
 static int json_parse_object(struct json_parse_state_s* state,
-  struct json_object_s* object) {
+                             int ignore_brackets,
+                             struct json_object_s* object) {
   size_t elements = 0;
   int allow_comma = 0;
   struct json_object_element_s* previous = 0;
 
-  if ('{' != state->src[state->offset]) {
-    // expected object to begin with leading '{'
-    return 1;
-  }
+  if (!ignore_brackets) {
+    if ('{' != state->src[state->offset]) {
+      // expected object to begin with leading '{'
+      return 1;
+    }
 
-  // skip leading '{'
-  state->offset++;
+    // skip leading '{'
+    state->offset++;
 
-  if (json_skip_whitespace(state)) {
-    // consumed the whole buffer when we expected a value!
-    return 1;
-  }
-
-  if ('}' != state->src[state->offset]) {
-    // we have at least one element as we definitely don't have
-    // an empty object {   }!
-    elements++;
+    if (json_skip_whitespace(state)) {
+      // consumed the whole buffer when we expected a value!
+      return 1;
+    }
   }
 
   // reset elements
   elements = 0;
 
   while (state->offset < state->size) {
-	struct json_object_element_s* element = 0;
-	struct json_string_s* string = 0;
-	struct json_value_s* value = 0;
+    struct json_object_element_s* element = 0;
+    struct json_string_s* string = 0;
+    struct json_value_s* value = 0;
 
-    if (json_skip_whitespace(state)) {
-      // reached end of buffer before object was complete!
-      return 1;
-    }
+    if (ignore_brackets) {
+      if (json_skip_whitespace(state)) {
+        // since we are ignoring brackets, if we reach the end of the input
+        // string, we have reached the end of the object!
+        break;
+        ;
+      }
 
-    if ('}' == state->src[state->offset]) {
-      // skip trailing '}'
-      state->offset++;
+    } else {
+      if (json_skip_whitespace(state)) {
+        // reached end of buffer before object was complete!
+        return 1;
+      }
 
-      // finished the object!
-      break;
+      if ('}' == state->src[state->offset]) {
+        // skip trailing '}'
+        state->offset++;
+
+        // finished the object!
+        break;
+      }
     }
 
     // if we parsed at least one element previously, grok for a comma
@@ -509,11 +589,11 @@ static int json_parse_object(struct json_parse_state_s* state,
 
       // skip comma
       state->offset++;
-	  allow_comma = 0;
+      allow_comma = 0;
       continue;
     }
 
-    element = (struct json_object_element_s* )state->dom;
+    element = (struct json_object_element_s*)state->dom;
 
     state->dom += sizeof(struct json_object_element_s);
 
@@ -526,13 +606,13 @@ static int json_parse_object(struct json_parse_state_s* state,
 
     previous = element;
 
-    string = (struct json_string_s* )state->dom;
+    string = (struct json_string_s*)state->dom;
 
     state->dom += sizeof(struct json_string_s);
 
     element->name = string;
 
-    if (json_parse_string(state, string)) {
+    if (json_parse_id(state, string)) {
       // string parsing failed!
       return 1;
     }
@@ -555,7 +635,7 @@ static int json_parse_object(struct json_parse_state_s* state,
       return 1;
     }
 
-    value = (struct json_value_s* )state->dom;
+    value = (struct json_value_s*)state->dom;
 
     state->dom += sizeof(struct json_value_s);
 
@@ -568,7 +648,7 @@ static int json_parse_object(struct json_parse_state_s* state,
 
     // successfully parsed a name/value pair!
     elements++;
-	allow_comma = 1;
+    allow_comma = 1;
   }
 
   // if we had at least one element, end the linked list
@@ -586,7 +666,7 @@ static int json_parse_object(struct json_parse_state_s* state,
 }
 
 static int json_parse_array(struct json_parse_state_s* state,
-  struct json_array_s* array) {
+                            struct json_array_s* array) {
   size_t elements = 0;
   int allow_comma = 0;
   struct json_array_element_s* previous = 0;
@@ -608,8 +688,8 @@ static int json_parse_array(struct json_parse_state_s* state,
   elements = 0;
 
   while (state->offset < state->size) {
-	struct json_array_element_s* element = 0;
-	struct json_value_s* value = 0;
+    struct json_array_element_s* element = 0;
+    struct json_value_s* value = 0;
 
     if (json_skip_whitespace(state)) {
       // reached end of buffer before array was complete!
@@ -633,11 +713,11 @@ static int json_parse_array(struct json_parse_state_s* state,
 
       // skip comma
       state->offset++;
-	  allow_comma = 0;
+      allow_comma = 0;
       continue;
     }
 
-    element = (struct json_array_element_s* )state->dom;
+    element = (struct json_array_element_s*)state->dom;
 
     state->dom += sizeof(struct json_array_element_s);
 
@@ -650,7 +730,7 @@ static int json_parse_array(struct json_parse_state_s* state,
 
     previous = element;
 
-    value = (struct json_value_s* )state->dom;
+    value = (struct json_value_s*)state->dom;
 
     state->dom += sizeof(struct json_value_s);
 
@@ -663,7 +743,7 @@ static int json_parse_array(struct json_parse_state_s* state,
 
     // successfully parsed an array element!
     elements++;
-	allow_comma = 1;
+    allow_comma = 1;
   }
 
   // end the linked list
@@ -681,33 +761,33 @@ static int json_parse_array(struct json_parse_state_s* state,
 }
 
 static int json_parse_number(struct json_parse_state_s* state,
-  struct json_number_s* number) {
+                             struct json_number_s* number) {
   size_t size = 0;
 
   number->number = state->data;
 
   while (state->offset < state->size) {
     switch (state->src[state->offset]) {
-    default:
-      // we've reached the end of all valid number characters!
-      goto json_parse_number_cleanup;
-    case '+':
-    case '-':
-    case '0':
-    case '1':
-    case '2':
-    case '3':
-    case '4':
-    case '5':
-    case '6':
-    case '7':
-    case '8':
-    case '9':
-    case '.':
-    case 'e':
-    case 'E':
-      state->data[size++] = state->src[state->offset++];
-      break;
+      default:
+        // we've reached the end of all valid number characters!
+        goto json_parse_number_cleanup;
+      case '+':
+      case '-':
+      case '0':
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+      case '8':
+      case '9':
+      case '.':
+      case 'e':
+      case 'E':
+        state->data[size++] = state->src[state->offset++];
+        break;
     }
   }
 
@@ -725,88 +805,89 @@ json_parse_number_cleanup:
 }
 
 static int json_parse_value(struct json_parse_state_s* state,
-  struct json_value_s* value) {
+                            struct json_value_s* value) {
   if (json_skip_whitespace(state)) {
     // consumed the whole buffer when we expected a value!
     return 1;
   }
 
   switch (state->src[state->offset]) {
-  case '"':
-    value->type = json_type_string;
-    value->payload = state->dom;
-    state->dom += sizeof(struct json_string_s);
-    return json_parse_string(state, value->payload);
-  case '{':
-    value->type = json_type_object;
-    value->payload = state->dom;
-    state->dom += sizeof(struct json_object_s);
-    return json_parse_object(state, value->payload);
-  case '[':
-    value->type = json_type_array;
-    value->payload = state->dom;
-    state->dom += sizeof(struct json_array_s);
-    return json_parse_array(state, value->payload);
-  case '-':
-  case '0':
-  case '1':
-  case '2':
-  case '3':
-  case '4':
-  case '5':
-  case '6':
-  case '7':
-  case '8':
-  case '9':
-    value->type = json_type_number;
-    value->payload = state->dom;
-    state->dom += sizeof(struct json_number_s);
-    return json_parse_number(state, value->payload);
-  default:
-    if ((state->offset + 4) < state->size &&
-      't' == state->src[state->offset + 0] &&
-      'r' == state->src[state->offset + 1] &&
-      'u' == state->src[state->offset + 2] &&
-      'e' == state->src[state->offset + 3]) {
-      value->type = json_type_true;
-      value->payload = 0;
-      state->offset += 4;
-      return 0;
-    } else if ((state->offset + 5) < state->size &&
-      'f' == state->src[state->offset + 0] &&
-      'a' == state->src[state->offset + 1] &&
-      'l' == state->src[state->offset + 2] &&
-      's' == state->src[state->offset + 3] &&
-      'e' == state->src[state->offset + 4]) {
-      value->type = json_type_false;
-      value->payload = 0;
-      state->offset += 5;
-      return 0;
-    } else if ((state->offset + 4) < state->size &&
-      'n' == state->src[state->offset + 0] &&
-      'u' == state->src[state->offset + 1] &&
-      'l' == state->src[state->offset + 2] &&
-      'l' == state->src[state->offset + 3]) {
-      value->type = json_type_null;
-      value->payload = 0;
-      state->offset += 4;
-      return 0;
-    }
+    case '"':
+      value->type = json_type_string;
+      value->payload = state->dom;
+      state->dom += sizeof(struct json_string_s);
+      return json_parse_string(state, value->payload);
+    case '{':
+      value->type = json_type_object;
+      value->payload = state->dom;
+      state->dom += sizeof(struct json_object_s);
+      return json_parse_object(state, 0, value->payload);
+    case '[':
+      value->type = json_type_array;
+      value->payload = state->dom;
+      state->dom += sizeof(struct json_array_s);
+      return json_parse_array(state, value->payload);
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+      value->type = json_type_number;
+      value->payload = state->dom;
+      state->dom += sizeof(struct json_number_s);
+      return json_parse_number(state, value->payload);
+    default:
+      if ((state->offset + 4) < state->size &&
+          't' == state->src[state->offset + 0] &&
+          'r' == state->src[state->offset + 1] &&
+          'u' == state->src[state->offset + 2] &&
+          'e' == state->src[state->offset + 3]) {
+        value->type = json_type_true;
+        value->payload = 0;
+        state->offset += 4;
+        return 0;
+      } else if ((state->offset + 5) < state->size &&
+                 'f' == state->src[state->offset + 0] &&
+                 'a' == state->src[state->offset + 1] &&
+                 'l' == state->src[state->offset + 2] &&
+                 's' == state->src[state->offset + 3] &&
+                 'e' == state->src[state->offset + 4]) {
+        value->type = json_type_false;
+        value->payload = 0;
+        state->offset += 5;
+        return 0;
+      } else if ((state->offset + 4) < state->size &&
+                 'n' == state->src[state->offset + 0] &&
+                 'u' == state->src[state->offset + 1] &&
+                 'l' == state->src[state->offset + 2] &&
+                 'l' == state->src[state->offset + 3]) {
+        value->type = json_type_null;
+        value->payload = 0;
+        state->offset += 4;
+        return 0;
+      }
 
-    // invalid value!
-    return 1;
+      // invalid value!
+      return 1;
   }
 }
 
-struct json_value_s* json_parse_ex(const void* src, size_t src_size, struct json_parse_result_s* result) {
+struct json_value_s* json_parse_ex(const void* src, size_t src_size,
+                                   struct json_parse_result_s* result) {
   struct json_parse_state_s state;
   void* allocation;
 
   if (result) {
-	result->error = json_parse_error_none;
-	result->error_offset = 0;
-	result->error_line_no = 0;
-	result->error_row_no = 0;
+    result->error = json_parse_error_none;
+    result->error_offset = 0;
+    result->error_line_no = 0;
+    result->error_row_no = 0;
   }
 
   if (0 == src || 2 > src_size) {
@@ -822,15 +903,16 @@ struct json_value_s* json_parse_ex(const void* src, size_t src_size, struct json
   state.error = json_parse_error_none;
   state.dom_size = 0;
   state.data_size = 0;
+  state.parsing_simplfied = 0;
 
   if (json_get_value_size(&state)) {
     // parsing value's size failed (most likely an invalid JSON DOM!)
-	if (result) {
-	  result->error = state.error;
-	  result->error_offset = state.offset;
-	  result->error_line_no = state.line_no;
-	  result->error_row_no = state.offset - state.line_offset;
-	}
+    if (result) {
+      result->error = state.error;
+      result->error_offset = state.offset;
+      result->error_line_no = state.line_no;
+      result->error_row_no = state.offset - state.line_offset;
+    }
     return 0;
   }
 
@@ -852,7 +934,7 @@ struct json_value_s* json_parse_ex(const void* src, size_t src_size, struct json
 
   state.dom += sizeof(struct json_value_s);
 
-  if (json_parse_value(&state, (struct json_value_s* )allocation)) {
+  if (json_parse_value(&state, (struct json_value_s*)allocation)) {
     // really bad chi here
     free(allocation);
     return 0;
@@ -865,28 +947,98 @@ struct json_value_s* json_parse(const void* src, size_t src_size) {
   return json_parse_ex(src, src_size, NULL);
 }
 
-static int json_write_minified_get_value_size(const struct json_value_s* value, size_t* size);
+struct json_object_s* json_parse_simplified_json_ex(
+    const void* src, size_t src_size, struct json_parse_result_s* result) {
+  struct json_parse_state_s state;
+  void* allocation;
 
-static int json_write_minified_get_number_size(const struct json_number_s* number, size_t* size) {
-  *size += number->number_size; // the actual string of the number
+  if (result) {
+    result->error = json_parse_error_none;
+    result->error_offset = 0;
+    result->error_line_no = 0;
+    result->error_row_no = 0;
+  }
+
+  state.src = src;
+  state.size = src_size;
+  state.offset = 0;
+  state.line_no = 1;
+  state.line_offset = 0;
+  state.error = json_parse_error_none;
+  state.dom_size = 0;
+  state.data_size = 0;
+  state.parsing_simplfied = 1;
+
+  // simplified JSON always stars with a single object, with no brackets.
+  if (json_get_object_size(&state, 1)) {
+    // parsing value's size failed (most likely an invalid JSON DOM!)
+    if (result) {
+      result->error = state.error;
+      result->error_offset = state.offset;
+      result->error_line_no = state.line_no;
+      result->error_row_no = state.offset - state.line_offset;
+    }
+    return 0;
+  }
+
+  // our total allocation is the combination of the dom and data sizes (we
+  // first encode the structure of the JSON, and then the data referenced by
+  // the JSON values)
+  allocation = malloc(state.dom_size + state.data_size);
+
+  if (0 == allocation) {
+    // malloc failed!
+    return 0;
+  }
+
+  // reset offset so we can reuse it
+  state.offset = 0;
+
+  state.dom = allocation;
+  state.data = state.dom + state.dom_size;
+
+  state.dom += sizeof(struct json_value_s);
+
+  if (json_parse_object(&state, 1, (struct json_object_s*)allocation)) {
+    // really bad chi here
+    free(allocation);
+    return 0;
+  }
+
+  return allocation;
+}
+
+struct json_object_s* json_parse_simplified_json(const void* src,
+                                                 size_t src_size) {
+  return json_parse_simplified_json_ex(src, src_size, NULL);
+}
+
+static int json_write_minified_get_value_size(const struct json_value_s* value,
+                                              size_t* size);
+
+static int json_write_minified_get_number_size(
+    const struct json_number_s* number, size_t* size) {
+  *size += number->number_size;  // the actual string of the number
 
   return 0;
 }
 
-static int json_write_minified_get_string_size(const struct json_string_s* string, size_t* size) {
-  *size += string->string_size; // the actual string
-  *size += 2; // need to encode the surrounding '"' characters
+static int json_write_minified_get_string_size(
+    const struct json_string_s* string, size_t* size) {
+  *size += string->string_size;  // the actual string
+  *size += 2;  // need to encode the surrounding '"' characters
 
   return 0;
 }
 
-static int json_write_minified_get_array_size(const struct json_array_s* array, size_t* size) {
+static int json_write_minified_get_array_size(const struct json_array_s* array,
+                                              size_t* size) {
   struct json_array_element_s* element;
 
-  *size += 2; // '[' and ']'
+  *size += 2;  // '[' and ']'
 
   if (1 < array->length) {
-    *size += array->length - 1; // ','s seperate each element
+    *size += array->length - 1;  // ','s seperate each element
   }
 
   for (element = array->start; 0 != element; element = element->next) {
@@ -899,15 +1051,16 @@ static int json_write_minified_get_array_size(const struct json_array_s* array, 
   return 0;
 }
 
-static int json_write_minified_get_object_size(const struct json_object_s* object, size_t* size) {
+static int json_write_minified_get_object_size(
+    const struct json_object_s* object, size_t* size) {
   struct json_object_element_s* element;
 
-  *size += 2; // '{' and '}'
+  *size += 2;  // '{' and '}'
 
-  *size += object->length; // ':'s seperate each name/value pair
+  *size += object->length;  // ':'s seperate each name/value pair
 
   if (1 < object->length) {
-    *size += object->length - 1; // ','s seperate each element
+    *size += object->length - 1;  // ','s seperate each element
   }
 
   for (element = object->start; 0 != element; element = element->next) {
@@ -925,34 +1078,41 @@ static int json_write_minified_get_object_size(const struct json_object_s* objec
   return 0;
 }
 
-static int json_write_minified_get_value_size(const struct json_value_s* value, size_t* size) {
+static int json_write_minified_get_value_size(const struct json_value_s* value,
+                                              size_t* size) {
   switch (value->type) {
-  default:
-    // unknown value type found!
-    return 1;
-  case json_type_number:
-    return json_write_minified_get_number_size((struct json_number_s* )value->payload, size);
-  case json_type_string:
-    return json_write_minified_get_string_size((struct json_string_s* )value->payload, size);
-  case json_type_array:
-    return json_write_minified_get_array_size((struct json_array_s* )value->payload, size);
-  case json_type_object:
-    return json_write_minified_get_object_size((struct json_object_s* )value->payload, size);
-  case json_type_true:
-    *size += 4; // the string "true"
-    return 0;
-  case json_type_false:
-    *size += 5; // the string "false"
-    return 0;
-  case json_type_null:
-    *size += 4; // the string "null"
-    return 0;
+    default:
+      // unknown value type found!
+      return 1;
+    case json_type_number:
+      return json_write_minified_get_number_size(
+          (struct json_number_s*)value->payload, size);
+    case json_type_string:
+      return json_write_minified_get_string_size(
+          (struct json_string_s*)value->payload, size);
+    case json_type_array:
+      return json_write_minified_get_array_size(
+          (struct json_array_s*)value->payload, size);
+    case json_type_object:
+      return json_write_minified_get_object_size(
+          (struct json_object_s*)value->payload, size);
+    case json_type_true:
+      *size += 4;  // the string "true"
+      return 0;
+    case json_type_false:
+      *size += 5;  // the string "false"
+      return 0;
+    case json_type_null:
+      *size += 4;  // the string "null"
+      return 0;
   }
 }
 
-static char* json_write_minified_value(const struct json_value_s* value, char* data);
+static char* json_write_minified_value(const struct json_value_s* value,
+                                       char* data);
 
-static char* json_write_minified_number(const struct json_number_s* number, char* data) {
+static char* json_write_minified_number(const struct json_number_s* number,
+                                        char* data) {
   size_t i;
 
   for (i = 0; i < number->number_size; i++) {
@@ -962,28 +1122,30 @@ static char* json_write_minified_number(const struct json_number_s* number, char
   return data;
 }
 
-static char* json_write_minified_string(const struct json_string_s* string, char* data) {
+static char* json_write_minified_string(const struct json_string_s* string,
+                                        char* data) {
   size_t i;
 
-  *data++ = '"'; // open the string
+  *data++ = '"';  // open the string
 
   for (i = 0; i < string->string_size; i++) {
-    *data++ = ((char* )string->string)[i];
+    *data++ = ((char*)string->string)[i];
   }
 
-  *data++ = '"'; // close the string
+  *data++ = '"';  // close the string
 
   return data;
 }
 
-static char* json_write_minified_array(const struct json_array_s* array, char* data) {
+static char* json_write_minified_array(const struct json_array_s* array,
+                                       char* data) {
   struct json_array_element_s* element = 0;
 
-  *data++ = '['; // open the array
+  *data++ = '[';  // open the array
 
   for (element = array->start; 0 != element; element = element->next) {
     if (element != array->start) {
-      *data++ = ','; // ','s seperate each element
+      *data++ = ',';  // ','s seperate each element
     }
 
     data = json_write_minified_value(element->value, data);
@@ -994,19 +1156,20 @@ static char* json_write_minified_array(const struct json_array_s* array, char* d
     }
   }
 
-  *data++ = ']'; // close the array
+  *data++ = ']';  // close the array
 
   return data;
 }
 
-static char* json_write_minified_object(const struct json_object_s* object, char* data) {
+static char* json_write_minified_object(const struct json_object_s* object,
+                                        char* data) {
   struct json_object_element_s* element = 0;
 
-  *data++ = '{'; // open the object
+  *data++ = '{';  // open the object
 
   for (element = object->start; 0 != element; element = element->next) {
     if (element != object->start) {
-      *data++ = ','; // ','s seperate each element
+      *data++ = ',';  // ','s seperate each element
     }
 
     data = json_write_minified_string(element->name, data);
@@ -1016,7 +1179,7 @@ static char* json_write_minified_object(const struct json_object_s* object, char
       return 0;
     }
 
-    *data++ = ':'; // ':'s seperate each name/value pair
+    *data++ = ':';  // ':'s seperate each name/value pair
 
     data = json_write_minified_value(element->value, data);
 
@@ -1026,43 +1189,48 @@ static char* json_write_minified_object(const struct json_object_s* object, char
     }
   }
 
-  *data++ = '}'; // close the object
+  *data++ = '}';  // close the object
 
   return data;
 }
 
-static char* json_write_minified_value(const struct json_value_s* value, char* data) {
+static char* json_write_minified_value(const struct json_value_s* value,
+                                       char* data) {
   switch (value->type) {
-  default:
-    // unknown value type found!
-    return 0;
-  case json_type_number:
-    return json_write_minified_number((struct json_number_s*)value->payload, data);
-  case json_type_string:
-    return json_write_minified_string((struct json_string_s*)value->payload, data);
-  case json_type_array:
-    return json_write_minified_array((struct json_array_s*)value->payload, data);
-  case json_type_object:
-    return json_write_minified_object((struct json_object_s*)value->payload, data);
-  case json_type_true:
-    data[0] = 't';
-    data[1] = 'r';
-    data[2] = 'u';
-    data[3] = 'e';
-    return data + 4;
-  case json_type_false:
-    data[0] = 'f';
-    data[1] = 'a';
-    data[2] = 'l';
-    data[3] = 's';
-    data[4] = 'e';
-    return data + 5;
-  case json_type_null:
-    data[0] = 'n';
-    data[1] = 'u';
-    data[2] = 'l';
-    data[3] = 'l';
-    return data + 4;
+    default:
+      // unknown value type found!
+      return 0;
+    case json_type_number:
+      return json_write_minified_number((struct json_number_s*)value->payload,
+                                        data);
+    case json_type_string:
+      return json_write_minified_string((struct json_string_s*)value->payload,
+                                        data);
+    case json_type_array:
+      return json_write_minified_array((struct json_array_s*)value->payload,
+                                       data);
+    case json_type_object:
+      return json_write_minified_object((struct json_object_s*)value->payload,
+                                        data);
+    case json_type_true:
+      data[0] = 't';
+      data[1] = 'r';
+      data[2] = 'u';
+      data[3] = 'e';
+      return data + 4;
+    case json_type_false:
+      data[0] = 'f';
+      data[1] = 'a';
+      data[2] = 'l';
+      data[3] = 's';
+      data[4] = 'e';
+      return data + 5;
+    case json_type_null:
+      data[0] = 'n';
+      data[1] = 'u';
+      data[2] = 'l';
+      data[3] = 'l';
+      return data + 4;
   }
 }
 
@@ -1071,16 +1239,16 @@ void* json_write_minified(const struct json_value_s* value, size_t* out_size) {
   char* data = 0;
   char* data_end = 0;
 
-	if (0 == value) {
+  if (0 == value) {
     return 0;
-	}
+  }
 
   if (json_write_minified_get_value_size(value, &size)) {
     // value was malformed!
     return 0;
   }
 
-  size += 1; // for the '\0' null terminating character
+  size += 1;  // for the '\0' null terminating character
 
   data = malloc(size);
 
@@ -1107,61 +1275,66 @@ void* json_write_minified(const struct json_value_s* value, size_t* out_size) {
   return data;
 }
 
-
 static int json_write_pretty_get_value_size(const struct json_value_s* value,
-  size_t depth, size_t indent_size, size_t newline_size, size_t* size);
+                                            size_t depth, size_t indent_size,
+                                            size_t newline_size, size_t* size);
 
-static int json_write_pretty_get_number_size(const struct json_number_s* number, size_t* size) {
-  *size += number->number_size; // the actual string of the number
+static int json_write_pretty_get_number_size(const struct json_number_s* number,
+                                             size_t* size) {
+  *size += number->number_size;  // the actual string of the number
 
   return 0;
 }
 
-static int json_write_pretty_get_string_size(const struct json_string_s* string, size_t* size) {
-  *size += string->string_size; // the actual string
-  *size += 2; // need to encode the surrounding '"' characters
+static int json_write_pretty_get_string_size(const struct json_string_s* string,
+                                             size_t* size) {
+  *size += string->string_size;  // the actual string
+  *size += 2;  // need to encode the surrounding '"' characters
 
   return 0;
 }
 
 static int json_write_pretty_get_array_size(const struct json_array_s* array,
-  size_t depth, size_t indent_size, size_t newline_size, size_t* size) {
+                                            size_t depth, size_t indent_size,
+                                            size_t newline_size, size_t* size) {
   struct json_array_element_s* element;
 
-  *size += 1; // '['
-  *size += newline_size; // need a newline next
+  *size += 1;             // '['
+  *size += newline_size;  // need a newline next
 
   if (1 < array->length) {
-    *size += (array->length - 1); // ','s seperate each element
+    *size += (array->length - 1);  // ','s seperate each element
   }
 
   for (element = array->start; 0 != element; element = element->next) {
     // each element gets an indent and newline
     *size += (depth + 1) * indent_size;
     *size += newline_size;
-    if (json_write_pretty_get_value_size(
-      element->value, depth + 1, indent_size, newline_size, size)) {
+    if (json_write_pretty_get_value_size(element->value, depth + 1, indent_size,
+                                         newline_size, size)) {
       // value was malformed!
       return 1;
     }
   }
 
   *size += depth * indent_size;
-  *size += 1; // ']'
-  *size += newline_size; // need a newline next
+  *size += 1;             // ']'
+  *size += newline_size;  // need a newline next
 
   return 0;
 }
 
 static int json_write_pretty_get_object_size(const struct json_object_s* object,
-  size_t depth, size_t indent_size, size_t newline_size, size_t* size) {
+                                             size_t depth, size_t indent_size,
+                                             size_t newline_size,
+                                             size_t* size) {
   struct json_object_element_s* element;
 
-  *size += 1; // '{'
-  *size += newline_size; // need a newline next
+  *size += 1;             // '{'
+  *size += newline_size;  // need a newline next
 
   if (1 < object->length) {
-    *size += object->length - 1; // ','s seperate each element
+    *size += object->length - 1;  // ','s seperate each element
   }
 
   for (element = object->start; 0 != element; element = element->next) {
@@ -1174,55 +1347,64 @@ static int json_write_pretty_get_object_size(const struct json_object_s* object,
       return 1;
     }
 
-    *size += 3; // seperate each name/value pair with " : "
+    *size += 3;  // seperate each name/value pair with " : "
 
-    if (json_write_pretty_get_value_size(element->value, depth + 1, indent_size, newline_size, size)) {
+    if (json_write_pretty_get_value_size(element->value, depth + 1, indent_size,
+                                         newline_size, size)) {
       // value was malformed!
       return 1;
     }
   }
 
   *size += depth * indent_size;
-  *size += 1; // '}'
+  *size += 1;  // '}'
 
-  if (0 != depth)
-  {
-    *size += newline_size; // need a newline next
+  if (0 != depth) {
+    *size += newline_size;  // need a newline next
   }
 
   return 0;
 }
 
 static int json_write_pretty_get_value_size(const struct json_value_s* value,
-  size_t depth, size_t indent_size, size_t newline_size, size_t* size) {
+                                            size_t depth, size_t indent_size,
+                                            size_t newline_size, size_t* size) {
   switch (value->type) {
-  default:
-    // unknown value type found!
-    return 1;
-  case json_type_number:
-    return json_write_pretty_get_number_size((struct json_number_s*)value->payload, size);
-  case json_type_string:
-    return json_write_pretty_get_string_size((struct json_string_s*)value->payload, size);
-  case json_type_array:
-    return json_write_pretty_get_array_size((struct json_array_s*)value->payload, depth, indent_size, newline_size, size);
-  case json_type_object:
-    return json_write_pretty_get_object_size((struct json_object_s*)value->payload, depth, indent_size, newline_size, size);
-  case json_type_true:
-    *size += 4; // the string "true"
-    return 0;
-  case json_type_false:
-    *size += 5; // the string "false"
-    return 0;
-  case json_type_null:
-    *size += 4; // the string "null"
-    return 0;
+    default:
+      // unknown value type found!
+      return 1;
+    case json_type_number:
+      return json_write_pretty_get_number_size(
+          (struct json_number_s*)value->payload, size);
+    case json_type_string:
+      return json_write_pretty_get_string_size(
+          (struct json_string_s*)value->payload, size);
+    case json_type_array:
+      return json_write_pretty_get_array_size(
+          (struct json_array_s*)value->payload, depth, indent_size,
+          newline_size, size);
+    case json_type_object:
+      return json_write_pretty_get_object_size(
+          (struct json_object_s*)value->payload, depth, indent_size,
+          newline_size, size);
+    case json_type_true:
+      *size += 4;  // the string "true"
+      return 0;
+    case json_type_false:
+      *size += 5;  // the string "false"
+      return 0;
+    case json_type_null:
+      *size += 4;  // the string "null"
+      return 0;
   }
 }
 
 static char* json_write_pretty_value(const struct json_value_s* value,
-  size_t depth, const char* indent, const char* newline, char* data);
+                                     size_t depth, const char* indent,
+                                     const char* newline, char* data);
 
-static char* json_write_pretty_number(const struct json_number_s* number, char* data) {
+static char* json_write_pretty_number(const struct json_number_s* number,
+                                      char* data) {
   size_t i;
 
   for (i = 0; i < number->number_size; i++) {
@@ -1232,26 +1414,28 @@ static char* json_write_pretty_number(const struct json_number_s* number, char* 
   return data;
 }
 
-static char* json_write_pretty_string(const struct json_string_s* string, char* data) {
+static char* json_write_pretty_string(const struct json_string_s* string,
+                                      char* data) {
   size_t i;
 
-  *data++ = '"'; // open the string
+  *data++ = '"';  // open the string
 
   for (i = 0; i < string->string_size; i++) {
     *data++ = ((char*)string->string)[i];
   }
 
-  *data++ = '"'; // close the string
+  *data++ = '"';  // close the string
 
   return data;
 }
 
 static char* json_write_pretty_array(const struct json_array_s* array,
-  size_t depth, const char* indent, const char* newline, char* data) {
+                                     size_t depth, const char* indent,
+                                     const char* newline, char* data) {
   size_t k, m;
   struct json_array_element_s* element;
 
-  *data++ = '['; // open the array
+  *data++ = '[';  // open the array
 
   for (k = 0; '\0' != newline[k]; k++) {
     *data++ = newline[k];
@@ -1259,7 +1443,7 @@ static char* json_write_pretty_array(const struct json_array_s* array,
 
   for (element = array->start; 0 != element; element = element->next) {
     if (element != array->start) {
-      *data++ = ','; // ','s seperate each element
+      *data++ = ',';  // ','s seperate each element
 
       for (k = 0; '\0' != newline[k]; k++) {
         *data++ = newline[k];
@@ -1272,7 +1456,8 @@ static char* json_write_pretty_array(const struct json_array_s* array,
       }
     }
 
-    data = json_write_pretty_value(element->value, depth + 1, indent, newline, data);
+    data = json_write_pretty_value(element->value, depth + 1, indent, newline,
+                                   data);
 
     if (0 == data) {
       // value was malformed!
@@ -1290,17 +1475,18 @@ static char* json_write_pretty_array(const struct json_array_s* array,
     }
   }
 
-  *data++ = ']'; // close the array
+  *data++ = ']';  // close the array
 
   return data;
 }
 
 static char* json_write_pretty_object(const struct json_object_s* object,
-  size_t depth, const char* indent, const char* newline, char* data) {
+                                      size_t depth, const char* indent,
+                                      const char* newline, char* data) {
   size_t k, m;
   struct json_object_element_s* element;
 
-  *data++ = '{'; // open the object
+  *data++ = '{';  // open the object
 
   for (k = 0; '\0' != newline[k]; k++) {
     *data++ = newline[k];
@@ -1308,7 +1494,7 @@ static char* json_write_pretty_object(const struct json_object_s* object,
 
   for (element = object->start; 0 != element; element = element->next) {
     if (element != object->start) {
-      *data++ = ','; // ','s seperate each element
+      *data++ = ',';  // ','s seperate each element
 
       for (k = 0; '\0' != newline[k]; k++) {
         *data++ = newline[k];
@@ -1333,7 +1519,8 @@ static char* json_write_pretty_object(const struct json_object_s* object,
     *data++ = ':';
     *data++ = ' ';
 
-    data = json_write_pretty_value(element->value, depth + 1, indent, newline, data);
+    data = json_write_pretty_value(element->value, depth + 1, indent, newline,
+                                   data);
 
     if (0 == data) {
       // value was malformed!
@@ -1351,51 +1538,54 @@ static char* json_write_pretty_object(const struct json_object_s* object,
     }
   }
 
-  *data++ = '}'; // close the object
+  *data++ = '}';  // close the object
 
   return data;
 }
 
 static char* json_write_pretty_value(const struct json_value_s* value,
-  size_t depth, const char* indent, const char* newline, char* data) {
+                                     size_t depth, const char* indent,
+                                     const char* newline, char* data) {
   switch (value->type) {
-  default:
-    // unknown value type found!
-    return 0;
-  case json_type_number:
-    return json_write_pretty_number((struct json_number_s*)value->payload, data);
-  case json_type_string:
-    return json_write_pretty_string((struct json_string_s*)value->payload, data);
-  case json_type_array:
-    return json_write_pretty_array((struct json_array_s*)value->payload, depth, indent, newline, data);
-  case json_type_object:
-    return json_write_pretty_object((struct json_object_s*)value->payload, depth, indent, newline, data);
-  case json_type_true:
-    data[0] = 't';
-    data[1] = 'r';
-    data[2] = 'u';
-    data[3] = 'e';
-    return data + 4;
-  case json_type_false:
-    data[0] = 'f';
-    data[1] = 'a';
-    data[2] = 'l';
-    data[3] = 's';
-    data[4] = 'e';
-    return data + 5;
-  case json_type_null:
-    data[0] = 'n';
-    data[1] = 'u';
-    data[2] = 'l';
-    data[3] = 'l';
-    return data + 4;
+    default:
+      // unknown value type found!
+      return 0;
+    case json_type_number:
+      return json_write_pretty_number((struct json_number_s*)value->payload,
+                                      data);
+    case json_type_string:
+      return json_write_pretty_string((struct json_string_s*)value->payload,
+                                      data);
+    case json_type_array:
+      return json_write_pretty_array((struct json_array_s*)value->payload,
+                                     depth, indent, newline, data);
+    case json_type_object:
+      return json_write_pretty_object((struct json_object_s*)value->payload,
+                                      depth, indent, newline, data);
+    case json_type_true:
+      data[0] = 't';
+      data[1] = 'r';
+      data[2] = 'u';
+      data[3] = 'e';
+      return data + 4;
+    case json_type_false:
+      data[0] = 'f';
+      data[1] = 'a';
+      data[2] = 'l';
+      data[3] = 's';
+      data[4] = 'e';
+      return data + 5;
+    case json_type_null:
+      data[0] = 'n';
+      data[1] = 'u';
+      data[2] = 'l';
+      data[3] = 'l';
+      return data + 4;
   }
 }
 
-void* json_write_pretty(const struct json_value_s* value,
-  const char* indent,
-  const char* newline,
-  size_t* out_size) {
+void* json_write_pretty(const struct json_value_s* value, const char* indent,
+                        const char* newline, size_t* out_size) {
   size_t size = 0;
   size_t indent_size = 0;
   size_t newline_size = 0;
@@ -1407,27 +1597,28 @@ void* json_write_pretty(const struct json_value_s* value,
   }
 
   if (0 == indent) {
-    indent = "  "; // default to two spaces
+    indent = "  ";  // default to two spaces
   }
 
   if (0 == newline) {
-    newline = "\n"; // default to linux newlines
+    newline = "\n";  // default to linux newlines
   }
 
   while ('\0' != indent[indent_size]) {
-    ++indent_size; // skip non-null terminating characters
+    ++indent_size;  // skip non-null terminating characters
   }
 
   while ('\0' != newline[newline_size]) {
-    ++newline_size; // skip non-null terminating characters
+    ++newline_size;  // skip non-null terminating characters
   }
 
-  if (json_write_pretty_get_value_size(value, 0, indent_size, newline_size, &size)) {
+  if (json_write_pretty_get_value_size(value, 0, indent_size, newline_size,
+                                       &size)) {
     // value was malformed!
     return 0;
   }
 
-  size += 1; // for the '\0' null terminating character
+  size += 1;  // for the '\0' null terminating character
 
   data = malloc(size);
 
@@ -1442,7 +1633,7 @@ void* json_write_pretty(const struct json_value_s* value,
     // bad chi occurred!
     free(data);
     return 0;
-}
+  }
 
   // null terminated the string
   *data_end = '\0';

--- a/json.h
+++ b/json.h
@@ -44,11 +44,33 @@ struct json_parse_result_s;
 // Parse a JSON text file, returning a pointer to the root of the JSON
 // structure. json_parse performs 1 call to malloc for the entire encoding.
 // Returns 0 if an error occurred (malformed JSON input, or malloc failed)
-struct json_value_s* json_parse(
-  const void* src, size_t src_size);
+struct json_value_s* json_parse(const void* src, size_t src_size);
 
-struct json_value_s* json_parse_ex(
-  const void* src, size_t src_size, struct json_parse_result_s* result);
+// Parse a JSON text file, returning a pointer to the root of the JSON
+// structure. json_parse_ex performs 1 call to malloc for the entire encoding.
+// Returns 0 if an error occurred (malformed JSON input, or malloc failed). If
+// result is not NULL, the cause of the error will be written into the
+// json_parse_result_s struct.
+struct json_value_s* json_parse_ex(const void* src, size_t src_size,
+                                   struct json_parse_result_s* result);
+
+// Parse a simplified JSON text file, returning a pointer to the object at the
+// root of the
+// simplified JSON structure. json_parse_simplified_json performs 1 call to
+// malloc for the entire encoding.
+// Returns 0 if an error occurred (malformed JSON input, or malloc failed)
+struct json_object_s* json_parse_simplified_json(const void* src,
+                                                 size_t src_size);
+
+// Parse a simplified JSON text file, returning a pointer to the object at the
+// root of the
+// simplified. json_parse_simplified_json_ex performs 1 call to malloc for the
+// entire
+// encoding. Returns 0 if an error occurred (malformed JSON input, or malloc
+// failed). If result is not NULL, the cause of the error will be written into
+// the json_parse_result_s struct.
+struct json_object_s* json_parse_simplified_json_ex(
+    const void* src, size_t src_size, struct json_parse_result_s* result);
 
 // Write out a minified JSON utf-8 string. This string is an encoding of the
 // minimal string characters required to still encode the same data.
@@ -66,10 +88,8 @@ void* json_write_minified(const struct json_value_s* value, size_t* out_size);
 // json_write_pretty performs 1 call to malloc for the entire encoding.
 // Return 0 if an error occurred (malformed JSON input, or malloc failed).
 // The out_size parameter is optional as the utf-8 string is null terminated.
-void* json_write_pretty(const struct json_value_s* value,
-  const char* indent,
-  const char* newline,
-  size_t* out_size);
+void* json_write_pretty(const struct json_value_s* value, const char* indent,
+                        const char* newline, size_t* out_size);
 
 // The various types JSON values can be. Used to identify what a value is
 enum json_type_e {
@@ -146,13 +166,31 @@ struct json_value_s {
 // a parsing error code
 enum json_parse_error_e {
   json_parse_error_none = 0,
-  json_parse_error_expected_comma,                  // expected a comma where there was none!
-  json_parse_error_expected_colon,					// colon separating name/value pair was missing!
-  json_parse_error_expected_opening_quote,          // expected string to begin with '"'!
-  json_parse_error_invalid_string_escape_sequence,	// invalid escaped sequence in string!
-  json_parse_error_invalid_number_format,           // invalid number format!
-  json_parse_error_invalid_value,                   // invalid value!
-  json_parse_error_premature_end_of_buffer,         // reached end of buffer before object/array was complete!
+
+  // expected a comma where there was none!
+  json_parse_error_expected_comma,
+
+  // colon separating name/value pair was missing!
+  json_parse_error_expected_colon,
+
+  // expected string to begin with '"'!
+  json_parse_error_expected_opening_quote,
+
+  // invalid escaped sequence in string!
+  json_parse_error_invalid_string_escape_sequence,
+  // invalid number format!
+  json_parse_error_invalid_number_format,
+
+  // invalid value!
+  json_parse_error_invalid_value,
+
+  // reached end of buffer before object/array was complete!
+  json_parse_error_premature_end_of_buffer,
+
+  // expected a identifier for an object member!
+  json_parse_error_expected_identifier,
+
+  // catch-all error for anything else that went wrong
   json_parse_error_unknown
 };
 
@@ -169,11 +207,11 @@ struct json_parse_result_s {
 };
 
 #ifdef __cplusplus
-} // extern "C"
+}  // extern "C"
 #endif
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 
-#endif//SHEREDOM_JSON_H_INCLUDED
+#endif  // SHEREDOM_JSON_H_INCLUDED


### PR DESCRIPTION
I've added two new entry points to parse simplified json. One caveat is they return a json_object_s -> my assumption here is that simplified json always has an non-bracketed object at global scope.