### PR TITLE
Enable simplified json

### DIFF
--- a/json.c
+++ b/json.c
@@ -192,6 +192,11 @@ static int json_get_object_size(struct json_parse_state_s *state) {
 
       if (json_parse_flags_allow_trailing_comma & state->flags_bitset) {
         continue;
+      } else {
+        if (json_skip_whitespace(state)) {
+          state->error = json_parse_error_premature_end_of_buffer;
+          return 1;
+        }
       }
     }
 

--- a/json.c
+++ b/json.c
@@ -945,8 +945,8 @@ struct json_value_s *json_parse_ex(const void *src, size_t src_size,
   state.flags_bitset = flags_bitset;
 
   if (json_get_value_size(
-          &state, /* is_global_object = */ (json_flag_allow_global_object &
-                                            state.flags_bitset))) {
+          &state, /* is_global_object = */ (
+              json_parse_flag_allow_global_object & state.flags_bitset))) {
     // parsing value's size failed (most likely an invalid JSON DOM!)
     if (result) {
       result->error = state.error;
@@ -975,9 +975,10 @@ struct json_value_s *json_parse_ex(const void *src, size_t src_size,
 
   state.dom += sizeof(struct json_value_s);
 
-  if (json_parse_value(&state, /* is_global_object = */ (
-                           json_flag_allow_global_object & state.flags_bitset),
-                       (struct json_value_s *)allocation)) {
+  if (json_parse_value(
+          &state, /* is_global_object = */ (
+              json_parse_flag_allow_global_object & state.flags_bitset),
+          (struct json_value_s *)allocation)) {
     // really bad chi here
     free(allocation);
     return 0;

--- a/json.c
+++ b/json.c
@@ -47,6 +47,7 @@ struct json_parse_state_s {
   char* data;
   size_t dom_size;
   size_t data_size;
+  size_t flags_bitset;
 };
 
 static int json_is_hexadecimal_digit(const char c) {
@@ -190,7 +191,10 @@ static int json_get_object_size(struct json_parse_state_s* state) {
       // skip comma
       state->offset++;
 	  allow_comma = 0;
-      continue;
+
+      if (json_parse_flags_allow_trailing_comma & state->flags_bitset) {
+        continue;
+      }
     }
 
     if (json_get_string_size(state)) {
@@ -798,7 +802,7 @@ static int json_parse_value(struct json_parse_state_s* state,
   }
 }
 
-struct json_value_s* json_parse_ex(const void* src, size_t src_size, struct json_parse_result_s* result) {
+struct json_value_s* json_parse_ex(const void* src, size_t src_size, size_t flags_bitset, struct json_parse_result_s* result) {
   struct json_parse_state_s state;
   void* allocation;
 
@@ -822,6 +826,7 @@ struct json_value_s* json_parse_ex(const void* src, size_t src_size, struct json
   state.error = json_parse_error_none;
   state.dom_size = 0;
   state.data_size = 0;
+  state.flags_bitset = flags_bitset;
 
   if (json_get_value_size(&state)) {
     // parsing value's size failed (most likely an invalid JSON DOM!)
@@ -862,7 +867,7 @@ struct json_value_s* json_parse_ex(const void* src, size_t src_size, struct json
 }
 
 struct json_value_s* json_parse(const void* src, size_t src_size) {
-  return json_parse_ex(src, src_size, NULL);
+  return json_parse_ex(src, src_size, json_parse_flags_default, NULL);
 }
 
 static int json_write_minified_get_value_size(const struct json_value_s* value, size_t* size);

--- a/json.c
+++ b/json.c
@@ -25,6 +25,8 @@
 
 #include "json.h"
 
+#include <stdlib.h>
+
 // we do one big allocation via malloc, then cast aligned slices of this for
 // our structures - we don't have a way to tell the compiler we know what we
 // are doing, so disable the warning instead!

--- a/json.c
+++ b/json.c
@@ -1,3 +1,6 @@
+// The latest version of this library is available on GitHub;
+//   https://github.com/sheredom/json.h
+
 // This is free and unencumbered software released into the public domain.
 //
 // Anyone is free to copy, modify, publish, use, compile, sell, or

--- a/json.c
+++ b/json.c
@@ -486,10 +486,11 @@ static int json_parse_string(struct json_parse_state_s *state,
   // skip leading '"'
   state->offset++;
 
-  while (state->offset < state->size &&
-         ('"' != state->src[state->offset] ||
-          ('\\' == state->src[state->offset - 1] &&
-           '"' == state->src[state->offset]))) {
+  while (state->offset < state->size && '"' != state->src[state->offset]) {
+    if ('\\' == state->src[state->offset]) {
+      // copy reverse solidus character
+      state->data[size++] = state->src[state->offset++];
+    }
     state->data[size++] = state->src[state->offset++];
   }
 

--- a/json.c
+++ b/json.c
@@ -279,7 +279,15 @@ static int json_get_array_size(struct json_parse_state_s *state) {
       // skip comma
       state->offset++;
       allow_comma = 0;
-      continue;
+      
+      if (json_parse_flags_allow_trailing_comma & state->flags_bitset) {
+        continue;
+      } else {
+        if (json_skip_whitespace(state)) {
+          state->error = json_parse_error_premature_end_of_buffer;
+          return 1;
+        }
+      }
     }
 
     if (json_get_value_size(state)) {

--- a/json.c
+++ b/json.c
@@ -30,14 +30,17 @@
 
 #include <stdlib.h>
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+
 // we do one big allocation via malloc, then cast aligned slices of this for
 // our structures - we don't have a way to tell the compiler we know what we
 // are doing, so disable the warning instead!
-#if defined(__clang__)
-#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-align"
 #elif defined(_MSC_VER)
 #pragma warning(push)
+
+// disable 'function selected for inline expansion' warning
 #pragma warning(disable : 4711)
 #endif
 

--- a/json.h
+++ b/json.h
@@ -27,10 +27,11 @@
 #define SHEREDOM_JSON_H_INCLUDED
 
 #include <stddef.h>
-#include <stdlib.h>
 
 #if defined(_MSC_VER)
 #pragma warning(push)
+
+// disable 'bytes padding added after construct' warning
 #pragma warning(disable : 4820)
 #endif
 

--- a/json.h
+++ b/json.h
@@ -41,14 +41,26 @@ extern "C" {
 struct json_value_s;
 struct json_parse_result_s;
 
+enum json_parse_flags_e {
+  json_parse_flags_default = 0,
+  json_parse_flags_allow_trailing_comma = 0x1
+};
+
 // Parse a JSON text file, returning a pointer to the root of the JSON
 // structure. json_parse performs 1 call to malloc for the entire encoding.
 // Returns 0 if an error occurred (malformed JSON input, or malloc failed)
 struct json_value_s* json_parse(
   const void* src, size_t src_size);
 
+// Parse a JSON text file, returning a pointer to the root of the JSON
+// structure. json_parse performs 1 call to malloc for the entire encoding.
+// Returns 0 if an error occurred (malformed JSON input, or malloc failed). If 
+// an error occurred, the result struct (if not NULL) will explain the type of 
+// error, and the location in the input it occurred.
 struct json_value_s* json_parse_ex(
-  const void* src, size_t src_size, struct json_parse_result_s* result);
+  const void* src, size_t src_size,
+  size_t flags_bitset,
+  struct json_parse_result_s* result);
 
 // Write out a minified JSON utf-8 string. This string is an encoding of the
 // minimal string characters required to still encode the same data.

--- a/json.h
+++ b/json.h
@@ -46,9 +46,11 @@ enum json_parse_flags_e {
   json_parse_flags_default = 0,
   json_parse_flags_allow_trailing_comma = 0x1,
   json_parse_flags_allow_unquoted_keys = 0x2,
-  json_flag_allow_global_object = 0x4,
-  json_flag_allow_simplified_json = (json_parse_flags_allow_trailing_comma |
-    json_parse_flags_allow_unquoted_keys | json_flag_allow_global_object)
+  json_parse_flag_allow_global_object = 0x4,
+  json_parse_flag_allow_simplified_json =
+      (json_parse_flags_allow_trailing_comma |
+       json_parse_flags_allow_unquoted_keys |
+       json_parse_flag_allow_global_object)
 };
 
 // Parse a JSON text file, returning a pointer to the root of the JSON

--- a/json.h
+++ b/json.h
@@ -153,17 +153,31 @@ struct json_value_s {
 
 // a parsing error code
 enum json_parse_error_e {
+  // no error occurred (huzzah!)
   json_parse_error_none = 0,
-  json_parse_error_expected_comma, // expected a comma where there was none!
-  json_parse_error_expected_colon, // colon separating name/value pair was
-                                   // missing!
-  json_parse_error_expected_opening_quote, // expected string to begin with '"'!
-  json_parse_error_invalid_string_escape_sequence, // invalid escaped sequence
-                                                   // in string!
-  json_parse_error_invalid_number_format,          // invalid number format!
-  json_parse_error_invalid_value,                  // invalid value!
-  json_parse_error_premature_end_of_buffer, // reached end of buffer before
-                                            // object/array was complete!
+
+  // expected a comma where there was none!
+  json_parse_error_expected_comma,
+
+  // colon separating name/value pair was missing!
+  json_parse_error_expected_colon,
+
+  // expected string to begin with '"'!
+  json_parse_error_expected_opening_quote,
+
+  // invalid escaped sequence in string!
+  json_parse_error_invalid_string_escape_sequence,
+
+  // invalid number format!
+  json_parse_error_invalid_number_format,
+
+  // invalid value!
+  json_parse_error_invalid_value,
+
+  // reached end of buffer before object/array was complete!
+  json_parse_error_premature_end_of_buffer,
+
+  // catch-all error for everything else that exploded (real bad chi!)
   json_parse_error_unknown
 };
 
@@ -171,10 +185,13 @@ enum json_parse_error_e {
 struct json_parse_result_s {
   // the error code (one of json_parse_error_e)
   size_t error;
+
   // the character offset for the error in the JSON input
   size_t error_offset;
+
   // the line number for the error in the JSON input
   size_t error_line_no;
+
   // the row number for the error, in bytes
   size_t error_row_no;
 };

--- a/json.h
+++ b/json.h
@@ -45,7 +45,10 @@ struct json_parse_result_s;
 enum json_parse_flags_e {
   json_parse_flags_default = 0,
   json_parse_flags_allow_trailing_comma = 0x1,
-  json_parse_flags_allow_unquoted_keys = 0x2
+  json_parse_flags_allow_unquoted_keys = 0x2,
+  json_flag_allow_global_object = 0x4,
+  json_flag_allow_simplified_json = (json_parse_flags_allow_trailing_comma |
+    json_parse_flags_allow_unquoted_keys | json_flag_allow_global_object)
 };
 
 // Parse a JSON text file, returning a pointer to the root of the JSON

--- a/json.h
+++ b/json.h
@@ -1,3 +1,6 @@
+// The latest version of this library is available on GitHub;
+//   https://github.com/sheredom/json.h
+
 // This is free and unencumbered software released into the public domain.
 //
 // Anyone is free to copy, modify, publish, use, compile, sell, or

--- a/json.h
+++ b/json.h
@@ -49,25 +49,23 @@ enum json_parse_flags_e {
 // Parse a JSON text file, returning a pointer to the root of the JSON
 // structure. json_parse performs 1 call to malloc for the entire encoding.
 // Returns 0 if an error occurred (malformed JSON input, or malloc failed)
-struct json_value_s* json_parse(
-  const void* src, size_t src_size);
+struct json_value_s *json_parse(const void *src, size_t src_size);
 
 // Parse a JSON text file, returning a pointer to the root of the JSON
 // structure. json_parse performs 1 call to malloc for the entire encoding.
-// Returns 0 if an error occurred (malformed JSON input, or malloc failed). If 
-// an error occurred, the result struct (if not NULL) will explain the type of 
+// Returns 0 if an error occurred (malformed JSON input, or malloc failed). If
+// an error occurred, the result struct (if not NULL) will explain the type of
 // error, and the location in the input it occurred.
-struct json_value_s* json_parse_ex(
-  const void* src, size_t src_size,
-  size_t flags_bitset,
-  struct json_parse_result_s* result);
+struct json_value_s *json_parse_ex(const void *src, size_t src_size,
+                                   size_t flags_bitset,
+                                   struct json_parse_result_s *result);
 
 // Write out a minified JSON utf-8 string. This string is an encoding of the
 // minimal string characters required to still encode the same data.
 // json_write_minified performs 1 call to malloc for the entire encoding.
 // Return 0 if an error occurred (malformed JSON input, or malloc failed).
 // The out_size parameter is optional as the utf-8 string is null terminated.
-void* json_write_minified(const struct json_value_s* value, size_t* out_size);
+void *json_write_minified(const struct json_value_s *value, size_t *out_size);
 
 // Write out a pretty JSON utf-8 string. This string is encoded such that the
 // resultant JSON is pretty in that it is easily human readable. The indent and
@@ -78,10 +76,8 @@ void* json_write_minified(const struct json_value_s* value, size_t* out_size);
 // json_write_pretty performs 1 call to malloc for the entire encoding.
 // Return 0 if an error occurred (malformed JSON input, or malloc failed).
 // The out_size parameter is optional as the utf-8 string is null terminated.
-void* json_write_pretty(const struct json_value_s* value,
-  const char* indent,
-  const char* newline,
-  size_t* out_size);
+void *json_write_pretty(const struct json_value_s *value, const char *indent,
+                        const char *newline, size_t *out_size);
 
 // The various types JSON values can be. Used to identify what a value is
 enum json_type_e {
@@ -97,7 +93,7 @@ enum json_type_e {
 // A JSON string value
 struct json_string_s {
   // utf-8 string
-  void* string;
+  void *string;
   // the size (in bytes) of the string
   size_t string_size;
 };
@@ -105,7 +101,7 @@ struct json_string_s {
 // a JSON number value
 struct json_number_s {
   // ASCII string containing representation of the number
-  char* number;
+  char *number;
   // the size (in bytes) of the number
   size_t number_size;
 };
@@ -113,17 +109,17 @@ struct json_number_s {
 // an element of a JSON object
 struct json_object_element_s {
   // the name of this element
-  struct json_string_s* name;
+  struct json_string_s *name;
   // the value of this element
-  struct json_value_s* value;
+  struct json_value_s *value;
   // the next array element (can be NULL if the last element in the object)
-  struct json_object_element_s* next;
+  struct json_object_element_s *next;
 };
 
 // a JSON object value
 struct json_object_s {
   // a linked list of the elements in the array
-  struct json_object_element_s* start;
+  struct json_object_element_s *start;
   // the length of names and values (number of elements in the object)
   size_t length;
 };
@@ -131,15 +127,15 @@ struct json_object_s {
 // an element of a JSON array
 struct json_array_element_s {
   // the value of this element
-  struct json_value_s* value;
+  struct json_value_s *value;
   // the next array element (can be NULL if the last element in the array)
-  struct json_array_element_s* next;
+  struct json_array_element_s *next;
 };
 
 // a JSON array value
 struct json_array_s {
   // a linked list of the elements in the array
-  struct json_array_element_s* start;
+  struct json_array_element_s *start;
   // the number of elements in the array
   size_t length;
 };
@@ -149,7 +145,7 @@ struct json_value_s {
   // a pointer to either a json_string_s, json_number_s, json_object_s, or
   // json_array_s. Should be cast to the appropriate struct type based on what
   // the type of this value is
-  void* payload;
+  void *payload;
   // Must be one of json_type_e. If type is json_type_true, json_type_false, or
   // json_type_null, payload will be NULL
   size_t type;
@@ -158,13 +154,16 @@ struct json_value_s {
 // a parsing error code
 enum json_parse_error_e {
   json_parse_error_none = 0,
-  json_parse_error_expected_comma,                  // expected a comma where there was none!
-  json_parse_error_expected_colon,					// colon separating name/value pair was missing!
-  json_parse_error_expected_opening_quote,          // expected string to begin with '"'!
-  json_parse_error_invalid_string_escape_sequence,	// invalid escaped sequence in string!
-  json_parse_error_invalid_number_format,           // invalid number format!
-  json_parse_error_invalid_value,                   // invalid value!
-  json_parse_error_premature_end_of_buffer,         // reached end of buffer before object/array was complete!
+  json_parse_error_expected_comma, // expected a comma where there was none!
+  json_parse_error_expected_colon, // colon separating name/value pair was
+                                   // missing!
+  json_parse_error_expected_opening_quote, // expected string to begin with '"'!
+  json_parse_error_invalid_string_escape_sequence, // invalid escaped sequence
+                                                   // in string!
+  json_parse_error_invalid_number_format,          // invalid number format!
+  json_parse_error_invalid_value,                  // invalid value!
+  json_parse_error_premature_end_of_buffer, // reached end of buffer before
+                                            // object/array was complete!
   json_parse_error_unknown
 };
 
@@ -188,4 +187,4 @@ struct json_parse_result_s {
 #pragma warning(pop)
 #endif
 
-#endif//SHEREDOM_JSON_H_INCLUDED
+#endif // SHEREDOM_JSON_H_INCLUDED

--- a/json.h
+++ b/json.h
@@ -47,9 +47,21 @@ struct json_parse_result_s;
 
 enum json_parse_flags_e {
   json_parse_flags_default = 0,
+
+  // allow trailing commas in objects and arrays. For example, both [true,] and
+  // {"a" : null,} would be allowed with this option on.
   json_parse_flags_allow_trailing_comma = 0x1,
+
+  // allow unquoted keys for objects. For example, {a : null} would be allowed
+  // with this option on.
   json_parse_flags_allow_unquoted_keys = 0x2,
+
+  // allow a global unbracketed object. For example, a : null, b : true, c : {}
+  // would be allowed with this option on.
   json_parse_flag_allow_global_object = 0x4,
+
+  // allow simplified JSON to be parsed. Simplified JSON is an enabling of a set
+  // of other parsing options.
   json_parse_flag_allow_simplified_json =
       (json_parse_flags_allow_trailing_comma |
        json_parse_flags_allow_unquoted_keys |

--- a/json.h
+++ b/json.h
@@ -43,7 +43,8 @@ struct json_parse_result_s;
 
 enum json_parse_flags_e {
   json_parse_flags_default = 0,
-  json_parse_flags_allow_trailing_comma = 0x1
+  json_parse_flags_allow_trailing_comma = 0x1,
+  json_parse_flags_allow_unquoted_keys = 0x2
 };
 
 // Parse a JSON text file, returning a pointer to the root of the JSON
@@ -176,6 +177,9 @@ enum json_parse_error_e {
 
   // reached end of buffer before object/array was complete!
   json_parse_error_premature_end_of_buffer,
+
+  // string was malformed!
+  json_parse_error_invalid_string,
 
   // catch-all error for everything else that exploded (real bad chi!)
   json_parse_error_unknown

--- a/test/main.c
+++ b/test/main.c
@@ -25,6 +25,7 @@
 
 #include "json.h"
 
+#include <stdlib.h>
 #include <string.h>
 
 static int test_empty() {

--- a/test/main.c
+++ b/test/main.c
@@ -350,6 +350,58 @@ int test_numbers() {
   return 0;
 }
 
+int test_trailing_commas_in_object() {
+  const char no_element[] = "{,}";
+  const char one_element[] = "{\"a\" : true,}";
+  const char few_element[] = "{\"a\" : true, \"b\" : false,}";
+
+  struct json_value_s* value = 0;
+
+  // negative test, should fail!
+  value = json_parse(no_element, strlen(no_element));
+  if (0 != value) {
+    return 1;
+  }
+
+  // negative test, should fail!
+  value = json_parse(one_element, strlen(one_element));
+  if (0 != value) {
+    return 2;
+  }
+
+  // negative test, should fail!
+  value = json_parse(few_element, strlen(few_element));
+  if (0 != value) {
+    return 3;
+  }
+
+  // negative test, should fail? At present an empty array/object, with a comma,
+  // is considered bad chi. Is this a special case we should allow or not?
+  value = json_parse_ex(no_element, strlen(no_element),
+    json_parse_flags_allow_trailing_comma, 0);
+  if (0 != value) {
+    return 4;
+  }
+
+  // negative test, should fail!
+  value = json_parse_ex(one_element, strlen(one_element),
+    json_parse_flags_allow_trailing_comma, 0);
+  if (0 == value) {
+    return 5;
+  }
+  free(value);
+
+  // negative test, should fail!
+  value = json_parse_ex(few_element, strlen(few_element),
+    json_parse_flags_allow_trailing_comma, 0);
+  if (0 == value) {
+    return 6;
+  }
+  free(value);
+
+  return 0;
+}
+
 int main() {
   const int error_addition = 20;
   int result = test_empty();
@@ -380,6 +432,12 @@ int main() {
 
   if (0 != result) {
     return (4 * error_addition) + result;
+  }
+
+  result = test_trailing_commas_in_object();
+
+  if (0 != result) {
+    return (5 * error_addition) + result;
   }
 
   return 0;

--- a/test/main.c
+++ b/test/main.c
@@ -402,6 +402,58 @@ int test_trailing_commas_in_object() {
   return 0;
 }
 
+int test_trailing_commas_in_array() {
+  const char no_element[] = "[,]";
+  const char one_element[] = "[true,]";
+  const char few_element[] = "[true, false,]";
+
+  struct json_value_s* value = 0;
+
+  // negative test, should fail!
+  value = json_parse(no_element, strlen(no_element));
+  if (0 != value) {
+    return 1;
+  }
+
+  // negative test, should fail!
+  value = json_parse(one_element, strlen(one_element));
+  if (0 != value) {
+    return 2;
+  }
+
+  // negative test, should fail!
+  value = json_parse(few_element, strlen(few_element));
+  if (0 != value) {
+    return 3;
+  }
+
+  // negative test, should fail? At present an empty array/object, with a comma,
+  // is considered bad chi. Is this a special case we should allow or not?
+  value = json_parse_ex(no_element, strlen(no_element),
+    json_parse_flags_allow_trailing_comma, 0);
+  if (0 != value) {
+    return 4;
+  }
+
+  // negative test, should fail!
+  value = json_parse_ex(one_element, strlen(one_element),
+    json_parse_flags_allow_trailing_comma, 0);
+  if (0 == value) {
+    return 5;
+  }
+  free(value);
+
+  // negative test, should fail!
+  value = json_parse_ex(few_element, strlen(few_element),
+    json_parse_flags_allow_trailing_comma, 0);
+  if (0 == value) {
+    return 6;
+  }
+  free(value);
+
+  return 0;
+}
+
 int main() {
   const int error_addition = 20;
   int result = test_empty();
@@ -438,6 +490,12 @@ int main() {
 
   if (0 != result) {
     return (5 * error_addition) + result;
+  }
+
+  result = test_trailing_commas_in_array();
+
+  if (0 != result) {
+    return (6 * error_addition) + result;
   }
 
   return 0;


### PR DESCRIPTION
I've broken down the simplified json changes such that each bit can be enabled in turn (for users that want to, for instance, just enable a global object but force all keys to still be quoted).