### PR TITLE
allow non global object in global mode

### DIFF
--- a/test/allow_global_object.c
+++ b/test/allow_global_object.c
@@ -29,14 +29,15 @@
 
 TESTCASE(allow_global_object, empty) {
   const char payload[] = "";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_global_object, 0);
-  struct json_object_s* object = 0;
+  struct json_value_s *value = json_parse_ex(
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0);
+  struct json_object_s *object = 0;
 
   ASSERT_TRUE(value);
   ASSERT_TRUE(value->payload);
   ASSERT_EQ(json_type_object, value->type);
 
-  object = (struct json_object_s* )value->payload;
+  object = (struct json_object_s *)value->payload;
 
   ASSERT_FALSE(object->start);
   ASSERT_EQ(0, object->length);
@@ -46,16 +47,17 @@ TESTCASE(allow_global_object, empty) {
 
 TESTCASE(allow_global_object, string) {
   const char payload[] = "\"foo\" : \"Heyo, gaia?\"";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_global_object, 0);
-  struct json_object_s* object = 0;
-  struct json_value_s* value2 = 0;
-  struct json_string_s* string = 0;
+  struct json_value_s *value = json_parse_ex(
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0);
+  struct json_object_s *object = 0;
+  struct json_value_s *value2 = 0;
+  struct json_string_s *string = 0;
 
   ASSERT_TRUE(value);
   ASSERT_TRUE(value->payload);
   ASSERT_EQ(json_type_object, value->type);
 
-  object = (struct json_object_s* )value->payload;
+  object = (struct json_object_s *)value->payload;
 
   ASSERT_TRUE(object->start);
   ASSERT_EQ(1, object->length);
@@ -67,14 +69,15 @@ TESTCASE(allow_global_object, string) {
   ASSERT_TRUE(object->start->name->string);
   ASSERT_STREQ("foo", object->start->name->string);
   ASSERT_EQ(strlen("foo"), object->start->name->string_size);
-  ASSERT_EQ(strlen(object->start->name->string), object->start->name->string_size);
+  ASSERT_EQ(strlen(object->start->name->string),
+            object->start->name->string_size);
 
   value2 = object->start->value;
 
   ASSERT_TRUE(value2->payload);
   ASSERT_EQ(json_type_string, value2->type);
 
-  string = (struct json_string_s* )value2->payload;
+  string = (struct json_string_s *)value2->payload;
 
   ASSERT_TRUE(string->string);
   ASSERT_STREQ("Heyo, gaia?", string->string);
@@ -86,16 +89,17 @@ TESTCASE(allow_global_object, string) {
 
 TESTCASE(allow_global_object, number) {
   const char payload[] = "\"foo\" : -0.123e-42";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_global_object, 0);
-  struct json_object_s* object = 0;
-  struct json_value_s* value2 = 0;
-  struct json_number_s* number = 0;
+  struct json_value_s *value = json_parse_ex(
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0);
+  struct json_object_s *object = 0;
+  struct json_value_s *value2 = 0;
+  struct json_number_s *number = 0;
 
   ASSERT_TRUE(value);
   ASSERT_TRUE(value->payload);
   ASSERT_EQ(json_type_object, value->type);
 
-  object = (struct json_object_s* )value->payload;
+  object = (struct json_object_s *)value->payload;
 
   ASSERT_TRUE(object->start);
   ASSERT_EQ(1, object->length);
@@ -107,14 +111,15 @@ TESTCASE(allow_global_object, number) {
   ASSERT_TRUE(object->start->name->string);
   ASSERT_STREQ("foo", object->start->name->string);
   ASSERT_EQ(strlen("foo"), object->start->name->string_size);
-  ASSERT_EQ(strlen(object->start->name->string), object->start->name->string_size);
+  ASSERT_EQ(strlen(object->start->name->string),
+            object->start->name->string_size);
 
   value2 = object->start->value;
 
   ASSERT_TRUE(value2->payload);
   ASSERT_EQ(json_type_number, value2->type);
 
-  number = (struct json_number_s* )value2->payload;
+  number = (struct json_number_s *)value2->payload;
 
   ASSERT_TRUE(number->number);
   ASSERT_STREQ("-0.123e-42", number->number);
@@ -126,16 +131,17 @@ TESTCASE(allow_global_object, number) {
 
 TESTCASE(allow_global_object, object) {
   const char payload[] = "\"foo\" : {}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_global_object, 0);
-  struct json_object_s* object = 0;
-  struct json_value_s* value2 = 0;
-  struct json_object_s* object2 = 0;
+  struct json_value_s *value = json_parse_ex(
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0);
+  struct json_object_s *object = 0;
+  struct json_value_s *value2 = 0;
+  struct json_object_s *object2 = 0;
 
   ASSERT_TRUE(value);
   ASSERT_TRUE(value->payload);
   ASSERT_EQ(json_type_object, value->type);
 
-  object = (struct json_object_s* )value->payload;
+  object = (struct json_object_s *)value->payload;
 
   ASSERT_TRUE(object->start);
   ASSERT_EQ(1, object->length);
@@ -147,14 +153,15 @@ TESTCASE(allow_global_object, object) {
   ASSERT_TRUE(object->start->name->string);
   ASSERT_STREQ("foo", object->start->name->string);
   ASSERT_EQ(strlen("foo"), object->start->name->string_size);
-  ASSERT_EQ(strlen(object->start->name->string), object->start->name->string_size);
+  ASSERT_EQ(strlen(object->start->name->string),
+            object->start->name->string_size);
 
   value2 = object->start->value;
 
   ASSERT_TRUE(value2->payload);
   ASSERT_EQ(json_type_object, value2->type);
 
-  object2 = (struct json_object_s* )value2->payload;
+  object2 = (struct json_object_s *)value2->payload;
 
   ASSERT_FALSE(object2->start);
   ASSERT_EQ(0, object2->length);
@@ -164,16 +171,17 @@ TESTCASE(allow_global_object, object) {
 
 TESTCASE(allow_global_object, array) {
   const char payload[] = "\"foo\" : []";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_global_object, 0);
-  struct json_object_s* object = 0;
-  struct json_value_s* value2 = 0;
-  struct json_array_s* array = 0;
+  struct json_value_s *value = json_parse_ex(
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0);
+  struct json_object_s *object = 0;
+  struct json_value_s *value2 = 0;
+  struct json_array_s *array = 0;
 
   ASSERT_TRUE(value);
   ASSERT_TRUE(value->payload);
   ASSERT_EQ(json_type_object, value->type);
 
-  object = (struct json_object_s* )value->payload;
+  object = (struct json_object_s *)value->payload;
 
   ASSERT_TRUE(object->start);
   ASSERT_EQ(1, object->length);
@@ -185,14 +193,15 @@ TESTCASE(allow_global_object, array) {
   ASSERT_TRUE(object->start->name->string);
   ASSERT_STREQ("foo", object->start->name->string);
   ASSERT_EQ(strlen("foo"), object->start->name->string_size);
-  ASSERT_EQ(strlen(object->start->name->string), object->start->name->string_size);
+  ASSERT_EQ(strlen(object->start->name->string),
+            object->start->name->string_size);
 
   value2 = object->start->value;
 
   ASSERT_TRUE(value2->payload);
   ASSERT_EQ(json_type_array, value2->type);
 
-  array = (struct json_array_s* )value2->payload;
+  array = (struct json_array_s *)value2->payload;
 
   ASSERT_FALSE(array->start);
   ASSERT_EQ(0, array->length);
@@ -202,15 +211,16 @@ TESTCASE(allow_global_object, array) {
 
 TESTCASE(allow_global_object, true) {
   const char payload[] = "\"foo\" : true";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_global_object, 0);
-  struct json_object_s* object = 0;
-  struct json_value_s* value2 = 0;
+  struct json_value_s *value = json_parse_ex(
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0);
+  struct json_object_s *object = 0;
+  struct json_value_s *value2 = 0;
 
   ASSERT_TRUE(value);
   ASSERT_TRUE(value->payload);
   ASSERT_EQ(json_type_object, value->type);
 
-  object = (struct json_object_s* )value->payload;
+  object = (struct json_object_s *)value->payload;
 
   ASSERT_TRUE(object->start);
   ASSERT_EQ(1, object->length);
@@ -222,7 +232,8 @@ TESTCASE(allow_global_object, true) {
   ASSERT_TRUE(object->start->name->string);
   ASSERT_STREQ("foo", object->start->name->string);
   ASSERT_EQ(strlen("foo"), object->start->name->string_size);
-  ASSERT_EQ(strlen(object->start->name->string), object->start->name->string_size);
+  ASSERT_EQ(strlen(object->start->name->string),
+            object->start->name->string_size);
 
   value2 = object->start->value;
 
@@ -234,15 +245,16 @@ TESTCASE(allow_global_object, true) {
 
 TESTCASE(allow_global_object, false) {
   const char payload[] = "\"foo\" : false";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_global_object, 0);
-  struct json_object_s* object = 0;
-  struct json_value_s* value2 = 0;
+  struct json_value_s *value = json_parse_ex(
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0);
+  struct json_object_s *object = 0;
+  struct json_value_s *value2 = 0;
 
   ASSERT_TRUE(value);
   ASSERT_TRUE(value->payload);
   ASSERT_EQ(json_type_object, value->type);
 
-  object = (struct json_object_s* )value->payload;
+  object = (struct json_object_s *)value->payload;
 
   ASSERT_TRUE(object->start);
   ASSERT_EQ(1, object->length);
@@ -254,7 +266,8 @@ TESTCASE(allow_global_object, false) {
   ASSERT_TRUE(object->start->name->string);
   ASSERT_STREQ("foo", object->start->name->string);
   ASSERT_EQ(strlen("foo"), object->start->name->string_size);
-  ASSERT_EQ(strlen(object->start->name->string), object->start->name->string_size);
+  ASSERT_EQ(strlen(object->start->name->string),
+            object->start->name->string_size);
 
   value2 = object->start->value;
 
@@ -266,15 +279,16 @@ TESTCASE(allow_global_object, false) {
 
 TESTCASE(allow_global_object, null) {
   const char payload[] = "\"foo\" : null";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_global_object, 0);
-  struct json_object_s* object = 0;
-  struct json_value_s* value2 = 0;
+  struct json_value_s *value = json_parse_ex(
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0);
+  struct json_object_s *object = 0;
+  struct json_value_s *value2 = 0;
 
   ASSERT_TRUE(value);
   ASSERT_TRUE(value->payload);
   ASSERT_EQ(json_type_object, value->type);
 
-  object = (struct json_object_s* )value->payload;
+  object = (struct json_object_s *)value->payload;
 
   ASSERT_TRUE(object->start);
   ASSERT_EQ(1, object->length);
@@ -286,12 +300,31 @@ TESTCASE(allow_global_object, null) {
   ASSERT_TRUE(object->start->name->string);
   ASSERT_STREQ("foo", object->start->name->string);
   ASSERT_EQ(strlen("foo"), object->start->name->string_size);
-  ASSERT_EQ(strlen(object->start->name->string), object->start->name->string_size);
+  ASSERT_EQ(strlen(object->start->name->string),
+            object->start->name->string_size);
 
   value2 = object->start->value;
 
   ASSERT_FALSE(value2->payload);
   ASSERT_EQ(json_type_null, value2->type);
+
+  free(value);
+}
+
+TESTCASE(allow_global_object, not_a_global_object_afterall) {
+  const char payload[] = "{}";
+  struct json_value_s *value = json_parse_ex(
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0);
+  struct json_object_s *object = 0;
+
+  ASSERT_TRUE(value);
+  ASSERT_TRUE(value->payload);
+  ASSERT_EQ(json_type_object, value->type);
+
+  object = (struct json_object_s *)value->payload;
+
+  ASSERT_FALSE(object->start);
+  ASSERT_EQ(0, object->length);
 
   free(value);
 }


### PR DESCRIPTION
Add support for being in json_parse_flags_allow_global_object mode, but the user gives us a normal JSON object at the root of the DOM.