### PR TITLE
Allocators should have user_data.

### DIFF
--- a/json.h
+++ b/json.h
@@ -96,7 +96,8 @@ struct json_value_s *json_parse(const void *src, size_t src_size);
 // error, and the location in the input it occurred.
 struct json_value_s *json_parse_ex(const void *src, size_t src_size,
                                    size_t flags_bitset,
-                                   void*(*alloc_func_ptr)(size_t size),
+                                   void*(*alloc_func_ptr)(void *, size_t),
+                                   void *user_data,
                                    struct json_parse_result_s *result);
 
 // Write out a minified JSON utf-8 string. This string is an encoding of the

--- a/test/allow_c_style_comments.cpp
+++ b/test/allow_c_style_comments.cpp
@@ -29,7 +29,7 @@
 
 TESTCASE(allow_c_style_comments, single_line) {
   const char payload[] = "// a \n { // b \n \"foo\" // c \n : // d \n null // e \n } // f";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_c_style_comments, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_c_style_comments, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_value_s* value2 = 0;
 
@@ -61,7 +61,7 @@ TESTCASE(allow_c_style_comments, single_line) {
 
 TESTCASE(allow_c_style_comments, multi_line) {
   const char payload[] = "/* a */ { /* b */ \"foo\" /* c1 \n c2 */ : /* d */ null /* e1 \n e2 */ } /* f */";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_c_style_comments, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_c_style_comments, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_value_s* value2 = 0;
 

--- a/test/allow_equals_in_object.c
+++ b/test/allow_equals_in_object.c
@@ -29,7 +29,7 @@
 
 TESTCASE(allow_equals_in_object, string) {
   const char payload[] = "{\"foo\" = \"Heyo, gaia?\"}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_value_s* value2 = 0;
   struct json_string_s* string = 0;
@@ -69,7 +69,7 @@ TESTCASE(allow_equals_in_object, string) {
 
 TESTCASE(allow_equals_in_object, number) {
   const char payload[] = "{\"foo\" = -0.123e-42}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_value_s* value2 = 0;
   struct json_number_s* number = 0;
@@ -109,7 +109,7 @@ TESTCASE(allow_equals_in_object, number) {
 
 TESTCASE(allow_equals_in_object, object) {
   const char payload[] = "{\"foo\" = {}}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_value_s* value2 = 0;
   struct json_object_s* object2 = 0;
@@ -147,7 +147,7 @@ TESTCASE(allow_equals_in_object, object) {
 
 TESTCASE(allow_equals_in_object, array) {
   const char payload[] = "{\"foo\" = []}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_value_s* value2 = 0;
   struct json_array_s* array = 0;
@@ -185,7 +185,7 @@ TESTCASE(allow_equals_in_object, array) {
 
 TESTCASE(allow_equals_in_object, true) {
   const char payload[] = "{\"foo\" = true}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_value_s* value2 = 0;
 
@@ -217,7 +217,7 @@ TESTCASE(allow_equals_in_object, true) {
 
 TESTCASE(allow_equals_in_object, false) {
   const char payload[] = "{\"foo\" = false}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_value_s* value2 = 0;
 
@@ -249,7 +249,7 @@ TESTCASE(allow_equals_in_object, false) {
 
 TESTCASE(allow_equals_in_object, null) {
   const char payload[] = "{\"foo\" = null}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_equals_in_object, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_value_s* value2 = 0;
 

--- a/test/allow_global_object.c
+++ b/test/allow_global_object.c
@@ -30,7 +30,7 @@
 TESTCASE(allow_global_object, empty) {
   const char payload[] = "";
   struct json_value_s *value = json_parse_ex(
-      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0);
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0, 0);
   struct json_object_s *object = 0;
 
   ASSERT_TRUE(value);
@@ -48,7 +48,7 @@ TESTCASE(allow_global_object, empty) {
 TESTCASE(allow_global_object, string) {
   const char payload[] = "\"foo\" : \"Heyo, gaia?\"";
   struct json_value_s *value = json_parse_ex(
-      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0);
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0, 0);
   struct json_object_s *object = 0;
   struct json_value_s *value2 = 0;
   struct json_string_s *string = 0;
@@ -90,7 +90,7 @@ TESTCASE(allow_global_object, string) {
 TESTCASE(allow_global_object, number) {
   const char payload[] = "\"foo\" : -0.123e-42";
   struct json_value_s *value = json_parse_ex(
-      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0);
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0, 0);
   struct json_object_s *object = 0;
   struct json_value_s *value2 = 0;
   struct json_number_s *number = 0;
@@ -132,7 +132,7 @@ TESTCASE(allow_global_object, number) {
 TESTCASE(allow_global_object, object) {
   const char payload[] = "\"foo\" : {}";
   struct json_value_s *value = json_parse_ex(
-      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0);
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0, 0);
   struct json_object_s *object = 0;
   struct json_value_s *value2 = 0;
   struct json_object_s *object2 = 0;
@@ -172,7 +172,7 @@ TESTCASE(allow_global_object, object) {
 TESTCASE(allow_global_object, array) {
   const char payload[] = "\"foo\" : []";
   struct json_value_s *value = json_parse_ex(
-      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0);
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0, 0);
   struct json_object_s *object = 0;
   struct json_value_s *value2 = 0;
   struct json_array_s *array = 0;
@@ -212,7 +212,7 @@ TESTCASE(allow_global_object, array) {
 TESTCASE(allow_global_object, true) {
   const char payload[] = "\"foo\" : true";
   struct json_value_s *value = json_parse_ex(
-      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0);
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0, 0);
   struct json_object_s *object = 0;
   struct json_value_s *value2 = 0;
 
@@ -246,7 +246,7 @@ TESTCASE(allow_global_object, true) {
 TESTCASE(allow_global_object, false) {
   const char payload[] = "\"foo\" : false";
   struct json_value_s *value = json_parse_ex(
-      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0);
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0, 0);
   struct json_object_s *object = 0;
   struct json_value_s *value2 = 0;
 
@@ -280,7 +280,7 @@ TESTCASE(allow_global_object, false) {
 TESTCASE(allow_global_object, null) {
   const char payload[] = "\"foo\" : null";
   struct json_value_s *value = json_parse_ex(
-      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0);
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0, 0);
   struct json_object_s *object = 0;
   struct json_value_s *value2 = 0;
 
@@ -314,7 +314,7 @@ TESTCASE(allow_global_object, null) {
 TESTCASE(allow_global_object, not_a_global_object_afterall) {
   const char payload[] = "{}";
   struct json_value_s *value = json_parse_ex(
-      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0);
+      payload, strlen(payload), json_parse_flags_allow_global_object, 0, 0, 0);
   struct json_object_s *object = 0;
 
   ASSERT_TRUE(value);

--- a/test/allow_no_commas.c
+++ b/test/allow_no_commas.c
@@ -29,7 +29,7 @@
 
 TESTCASE(allow_no_commas, one) {
   const char payload[] = "{\"foo\" : true \"bar\" : false}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_no_commas, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_no_commas, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_object_element_s* element = 0;
   struct json_value_s* value2 = 0;
@@ -79,7 +79,7 @@ TESTCASE(allow_no_commas, one) {
 
 TESTCASE(allow_no_commas, two) {
   const char payload[] = "{\"foo\" : \"yada\"\"bar\" : null}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_no_commas, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_no_commas, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_object_element_s* element = 0;
   struct json_value_s* value2 = 0;

--- a/test/allow_string_simplification.c
+++ b/test/allow_string_simplification.c
@@ -29,7 +29,7 @@
 
 TESTCASE(allow_string_simplification, quotation) {
   const char payload[] = "[ \"\\\"\" ]";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0, 0);
   struct json_array_s* array = 0;
   struct json_value_s* value2 = 0;
   struct json_string_s* string = 0;
@@ -63,7 +63,7 @@ TESTCASE(allow_string_simplification, quotation) {
 
 TESTCASE(allow_string_simplification, reverse_solidus) {
   const char payload[] = "[ \"\\\\\" ]";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0, 0);
   struct json_array_s* array = 0;
   struct json_value_s* value2 = 0;
   struct json_string_s* string = 0;
@@ -97,7 +97,7 @@ TESTCASE(allow_string_simplification, reverse_solidus) {
 
 TESTCASE(allow_string_simplification, solidus) {
   const char payload[] = "[ \"\\/\" ]";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0, 0);
   struct json_array_s* array = 0;
   struct json_value_s* value2 = 0;
   struct json_string_s* string = 0;
@@ -131,7 +131,7 @@ TESTCASE(allow_string_simplification, solidus) {
 
 TESTCASE(allow_string_simplification, backspace) {
   const char payload[] = "[ \"\\b\" ]";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0, 0);
   struct json_array_s* array = 0;
   struct json_value_s* value2 = 0;
   struct json_string_s* string = 0;
@@ -165,7 +165,7 @@ TESTCASE(allow_string_simplification, backspace) {
 
 TESTCASE(allow_string_simplification, formfeed) {
   const char payload[] = "[ \"\\f\" ]";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0, 0);
   struct json_array_s* array = 0;
   struct json_value_s* value2 = 0;
   struct json_string_s* string = 0;
@@ -199,7 +199,7 @@ TESTCASE(allow_string_simplification, formfeed) {
 
 TESTCASE(allow_string_simplification, newline) {
   const char payload[] = "[ \"\\n\" ]";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0, 0);
   struct json_array_s* array = 0;
   struct json_value_s* value2 = 0;
   struct json_string_s* string = 0;
@@ -233,7 +233,7 @@ TESTCASE(allow_string_simplification, newline) {
 
 TESTCASE(allow_string_simplification, carriage_return) {
   const char payload[] = "[ \"\\r\" ]";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0, 0);
   struct json_array_s* array = 0;
   struct json_value_s* value2 = 0;
   struct json_string_s* string = 0;
@@ -267,7 +267,7 @@ TESTCASE(allow_string_simplification, carriage_return) {
 
 TESTCASE(allow_string_simplification, horizontal_tab) {
   const char payload[] = "[ \"\\t\" ]";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_string_simplification, 0, 0, 0);
   struct json_array_s* array = 0;
   struct json_value_s* value2 = 0;
   struct json_string_s* string = 0;

--- a/test/allow_trailing_comma.cpp
+++ b/test/allow_trailing_comma.cpp
@@ -30,7 +30,7 @@
 TESTCASE(allow_trailing_comma, object_no_element) {
   const char payload[] = "{,}";
   struct json_parse_result_s result;
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, &result);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, 0, &result);
 
   ASSERT_FALSE(value);
 
@@ -42,7 +42,7 @@ TESTCASE(allow_trailing_comma, object_no_element) {
 
 TESTCASE(allow_trailing_comma, object_one_element) {
   const char payload[] = "{\"foo\" : true, }";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, 0, 0);
   struct json_object_s* object = 0;
 
   ASSERT_TRUE(value);
@@ -69,7 +69,7 @@ TESTCASE(allow_trailing_comma, object_one_element) {
 
 TESTCASE(allow_trailing_comma, object_two_elements) {
   const char payload[] = "{\"foo\" : true, \"bar\" : false, }";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_object_element_s* element = 0;
 
@@ -112,7 +112,7 @@ TESTCASE(allow_trailing_comma, object_two_elements) {
 TESTCASE(allow_trailing_comma, array_no_element) {
   const char payload[] = "[,]";
   struct json_parse_result_s result;
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, &result);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, 0, &result);
 
   ASSERT_FALSE(value);
 
@@ -124,7 +124,7 @@ TESTCASE(allow_trailing_comma, array_no_element) {
 
 TESTCASE(allow_trailing_comma, array_one_element) {
   const char payload[] = "[ true, ]";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, 0, 0);
   struct json_array_s* object = 0;
 
   ASSERT_TRUE(value);
@@ -146,7 +146,7 @@ TESTCASE(allow_trailing_comma, array_one_element) {
 
 TESTCASE(allow_trailing_comma, array_two_elements) {
   const char payload[] = "[ true, false, ]";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_trailing_comma, 0, 0, 0);
   struct json_array_s* object = 0;
   struct json_array_element_s* element = 0;
 

--- a/test/allow_unquoted_keys.c
+++ b/test/allow_unquoted_keys.c
@@ -29,7 +29,7 @@
 
 TESTCASE(allow_unquoted_keys, one_key) {
   const char payload[] = "{foo : null}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_unquoted_keys, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_unquoted_keys, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_value_s* value2 = 0;
 
@@ -61,7 +61,7 @@ TESTCASE(allow_unquoted_keys, one_key) {
 
 TESTCASE(allow_unquoted_keys, mixed_keys) {
   const char payload[] = "{foo : true, \"heyo\" : false}";
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_unquoted_keys, 0, 0);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_unquoted_keys, 0, 0, 0);
   struct json_object_s* object = 0;
   struct json_object_element_s* element = 0;
   struct json_value_s* value2 = 0;
@@ -113,7 +113,7 @@ TESTCASE(allow_unquoted_keys, mixed_keys) {
 TESTCASE(allow_unquoted_keys, value_unquoted_fails) {
   const char payload[] = "{foo\n: heyo}";
   struct json_parse_result_s result;
-  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_unquoted_keys, 0, &result);
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_unquoted_keys, 0, 0, &result);
 
   ASSERT_FALSE(value);
 


### PR DESCRIPTION
When using the allocators I had just added, I realised that I really missed having some user data that I could pass the data to store into in. This commit fixes this missing functionality.