### PR TITLE
Added input buffer offsets to DOM objects and a line offset buffer.

### DIFF
--- a/json.h
+++ b/json.h
@@ -74,6 +74,10 @@ enum json_parse_flags_e {
   // allow JSON parsing to optimize incoming strings where appropriate.
   json_parse_flags_allow_string_simplification = 0x40,
 
+  // save line offsets in the JSON input to a separate buffer.
+  // a pointer to the buffer is returned in the json_parse_result_s struct.
+  json_parse_flags_save_line_offsets = 0x80,
+
   // allow simplified JSON to be parsed. Simplified JSON is an enabling of a set
   // of other parsing options.
   json_parse_flags_allow_simplified_json =
@@ -154,6 +158,8 @@ struct json_object_element_s {
   struct json_value_s *value;
   // the next object element (can be NULL if the last element in the object)
   struct json_object_element_s *next;
+  // the character offset of the element name in the JSON input
+  size_t offset;
 };
 
 // a JSON object value
@@ -189,6 +195,8 @@ struct json_value_s {
   // Must be one of json_type_e. If type is json_type_true, json_type_false, or
   // json_type_null, payload will be NULL
   size_t type;
+  // the character offset of this node in the JSON input
+  size_t offset;
 };
 
 // a parsing error code
@@ -227,7 +235,7 @@ enum json_parse_error_e {
   json_parse_error_unknown
 };
 
-// error report from json_parse_ex()
+// detailed result of json_parse_ex()
 struct json_parse_result_s {
   // the error code (one of json_parse_error_e)
   size_t error;
@@ -240,6 +248,12 @@ struct json_parse_result_s {
 
   // the row number for the error, in bytes
   size_t error_row_no;
+
+  // the buffer storing a character offset for each parsed line
+  size_t *line_offsets;
+
+  // the total number of parsed lines
+  size_t line_count;
 };
 
 #ifdef __cplusplus

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(json_test
   allow_string_simplification.c
   allow_trailing_comma.cpp
   allow_unquoted_keys.c
+  save_line_offsets.c
   main.c
   test.c
   test.cpp

--- a/test/main.c
+++ b/test/main.c
@@ -705,4 +705,31 @@ TESTCASE(number, eminus) {
   free(value);
 }
 
+TESTCASE(value, offsets) {
+  const char payload[] = "{ \"foo\" : true, \"bar\" : false }";
+  struct json_value_s* root_value = json_parse(payload, strlen(payload));
+  struct json_object_s* root_object = 0;
+  struct json_object_element_s* foo_element = 0;
+  struct json_object_element_s* bar_element = 0;
+
+  ASSERT_TRUE(root_value);
+  ASSERT_EQ(json_type_object, root_value->type);
+  root_object = (struct json_object_s *)root_value->payload;
+  ASSERT_TRUE(root_object->start);
+  foo_element = root_object->start;
+  ASSERT_TRUE(root_object->start->next);
+  bar_element = root_object->start->next;
+
+  ASSERT_TRUE(foo_element->value);
+  ASSERT_TRUE(bar_element->value);
+
+  ASSERT_EQ(0, root_value->offset);
+  ASSERT_EQ(2, foo_element->offset);
+  ASSERT_EQ(10, foo_element->value->offset);
+  ASSERT_EQ(16, bar_element->offset);
+  ASSERT_EQ(24, bar_element->value->offset);
+
+  free(root_value);
+}
+
 UTEST_MAIN();

--- a/test/save_line_offsets.c
+++ b/test/save_line_offsets.c
@@ -1,0 +1,51 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+//
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// For more information, please refer to <http://unlicense.org/>
+
+#include "utest.h"
+
+#include "json.h"
+
+TESTCASE(save_line_offsets, single_line) {
+  const char payload[] = "{}";
+  struct json_parse_result_s parse_result;
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_save_line_offsets, 0, 0, &parse_result);
+
+  ASSERT_EQ(1, parse_result.line_count);
+  ASSERT_EQ(0, parse_result.line_offsets[0]);
+
+  free(value);
+}
+
+TESTCASE(save_line_offsets, two_lines) {
+  const char payload[] = "{\n}";
+  struct json_parse_result_s parse_result;
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_save_line_offsets, 0, 0, &parse_result);
+
+  ASSERT_EQ(2, parse_result.line_count);
+  ASSERT_EQ(0, parse_result.line_offsets[0]);
+  ASSERT_EQ(1, parse_result.line_offsets[1]);
+
+  free(value);
+}


### PR DESCRIPTION
As discussed in #38 I'm adding line information to DOM objects.

- `json_value_s` stores a byte offset of the value
- `json_object_element_s` stores a byte offset of the element name
- line offset table is optionally exposed via `json_parse_result_s`
- offsets can be translated to locations using binary search client-side, e.g. by using `std::lower_bound`