### PR TITLE
Fix for errors in streams '{\**\\**\"a":"b"}' and '{ ' with comments

### DIFF
--- a/json.c
+++ b/json.c
@@ -65,14 +65,18 @@ static int json_is_hexadecimal_digit(const char c) {
 
 static int json_skip_whitespace(struct json_parse_state_s *state) {
   // the only valid whitespace according to ECMA-404 is ' ', '\n', '\r' and '\t'
+  const char s = state->src[state->offset];
+  if (s != '\n' && s != ' ' && s != '\r' && s != '\t')
+    return 0;
+
   for (; state->offset < state->size; state->offset++) {
     const char c = state->src[state->offset];
 
-    if ('\n' == c) {
+    if (c == '\n') {
       state->line_no++;
       state->line_offset = state->offset;
-    } else if ((' ' != c) && ('\r' != c) && ('\t' != c)) {
-      return 0;
+    } else if (c != ' ' && c != '\r' && c != '\t') {
+      return 1;
     }
   }
 
@@ -104,12 +108,12 @@ static int json_skip_c_style_comments(struct json_parse_state_s *state) {
           // we entered a newline, so move our line info forward
           state->line_no++;
           state->line_offset = state->offset;
-          return 0;
+          return 1;
         }
       }
 
       // we reached the end of the JSON file!
-      return 0;
+      return 1;
     } else if ('*' == state->src[state->offset]) {
       // we had a comment in the form /* */
 
@@ -121,7 +125,7 @@ static int json_skip_c_style_comments(struct json_parse_state_s *state) {
             ('/' == state->src[state->offset + 1])) {
           // we reached the end of our comment!
           state->offset += 2;
-          return 0;
+          return 1;
         } else if ('\n' == state->src[state->offset]) {
           // we entered a newline, so move our line info forward
           state->line_no++;
@@ -143,24 +147,33 @@ static int json_skip_c_style_comments(struct json_parse_state_s *state) {
 }
 
 static int json_skip_all_skippables(struct json_parse_state_s *state) {
-  // skip all whitespace first
-  if (json_skip_whitespace(state)) {
-    state->error = json_parse_error_premature_end_of_buffer;
-    return 1;
-  }
+  // skip all whitespace and other skippables until there are none left
+  // note that the previous version suffered from read past errors should
+  // the stream end on json_skip_c_style_comments eg. '{"a" ' with comments flag
 
-  // are we allowed to parse c style comments?
-  if (json_parse_flags_allow_c_style_comments & state->flags_bitset) {
-    // then skip all c style comments
-    if (json_skip_c_style_comments(state)) {
+  size_t did_consume = 0;
+  do {
+    if (state->offset == state-> size) {
       state->error = json_parse_error_premature_end_of_buffer;
       return 1;
     }
 
-    // and skip any whitespace that happened after the comment. We don't check
-    // this skip whitespace because it could be the case that the c-style
-    // comment was at the end of the file which is totally ok!
-    json_skip_whitespace(state);
+    did_consume = json_skip_whitespace(state);
+
+    if (json_parse_flags_allow_c_style_comments & state->flags_bitset) {
+      //This shoud really be checked on access, not in front of every call
+      if (state->offset == state-> size) {
+	state->error = json_parse_error_premature_end_of_buffer;
+        return 1;
+      }
+
+      did_consume |= json_skip_c_style_comments(state);
+    }
+  } while (did_consume != 0);
+
+  if (state->offset == state-> size) {
+    state->error = json_parse_error_premature_end_of_buffer;
+    return 1;
   }
 
   return 0;

--- a/test/allow_c_style_comments.cpp
+++ b/test/allow_c_style_comments.cpp
@@ -90,3 +90,37 @@ TESTCASE(allow_c_style_comments, multi_line) {
 
   free(value);
 }
+
+TESTCASE(allow_c_style_comments, multiple) {
+  const char payload[] = "{/**/ /**/\"foo\" : null}";
+  struct json_value_s* value = json_parse_ex(payload, strlen(payload), json_parse_flags_allow_c_style_comments, 0, 0, 0);
+  struct json_object_s* object = 0;
+  struct json_value_s* value2 = 0;
+
+  ASSERT_TRUE(value);
+  ASSERT_TRUE(value->payload);
+  ASSERT_EQ(json_type_object, value->type);
+
+  object = (struct json_object_s* )value->payload;
+
+  ASSERT_TRUE(object->start);
+  ASSERT_EQ(1, object->length);
+
+  ASSERT_TRUE(object->start->name);
+  ASSERT_TRUE(object->start->value);
+  ASSERT_FALSE(object->start->next); // we have only one element
+
+  ASSERT_TRUE(object->start->name->string);
+  ASSERT_STREQ("foo", object->start->name->string);
+  ASSERT_EQ(strlen("foo"), object->start->name->string_size);
+  ASSERT_EQ(strlen(object->start->name->string), object->start->name->string_size);
+
+  value2 = object->start->value;
+
+  ASSERT_FALSE(value2->payload);
+  ASSERT_EQ(json_type_null, value2->type);
+
+  free(value);
+}
+
+


### PR DESCRIPTION
Hi,

Those are fixes for bugs mostly caused by the design issue I told you about. I added a test case that tests for multiple comment - whitespace sequences. 

You should consider adding some tests that are done at the end of mmap'ed or VirtualAlloc'ed page - this way your code will segfault if it reads past the input buffer like it would on '{ '.

Fireice