### PR TITLE
1.19x performance improvements.

### DIFF
--- a/json.c
+++ b/json.c
@@ -55,14 +55,14 @@ struct json_parse_state_s {
   const char *src;
   size_t size;
   size_t offset;
+  size_t flags_bitset;
+  char *data;
+  char *dom;
+  size_t dom_size;
+  size_t data_size;
   size_t line_no;     // line counter for error reporting
   size_t line_offset; // (offset-line_offset) is the character number (in bytes)
   size_t error;
-  char *dom;
-  char *data;
-  size_t dom_size;
-  size_t data_size;
-  size_t flags_bitset;
 };
 
 static int json_is_hexadecimal_digit(const char c) {
@@ -71,8 +71,11 @@ static int json_is_hexadecimal_digit(const char c) {
 }
 
 static int json_skip_whitespace(struct json_parse_state_s *state) {
+  size_t offset = state->offset;
+  const size_t size = state->size;
+
   // the only valid whitespace according to ECMA-404 is ' ', '\n', '\r' and '\t'
-  switch (state->src[state->offset]) {
+  switch (state->src[offset]) {
   default:
     return 0;
   case ' ':
@@ -82,9 +85,11 @@ static int json_skip_whitespace(struct json_parse_state_s *state) {
     break;
   }
 
-  for (; state->offset < state->size; state->offset++) {
-    switch (state->src[state->offset]) {
+  for (; offset < size; offset++) {
+    switch (state->src[offset]) {
     default:
+      // Update offset
+      state->offset = offset;
       return 1;
     case ' ':
     case '\r':
@@ -92,11 +97,13 @@ static int json_skip_whitespace(struct json_parse_state_s *state) {
       break;
     case '\n':
       state->line_no++;
-      state->line_offset = state->offset;
+      state->line_offset = offset;
       break;
     }
   }
 
+  // Update offset
+  state->offset = offset;
   return 1;
 }
 
@@ -107,7 +114,7 @@ static int json_skip_c_style_comments(struct json_parse_state_s *state) {
     state->offset++;
 
     if ('/' == state->src[state->offset]) {
-      // we had a comment in the form //
+      // we had a comment of the form //
 
       // skip second '/'
       state->offset++;
@@ -169,26 +176,37 @@ static int json_skip_all_skippables(struct json_parse_state_s *state) {
   // the stream end on json_skip_c_style_comments eg. '{"a" ' with comments flag
 
   int did_consume = 0;
-  do {
-    if (state->offset == state-> size) {
-      state->error = json_parse_error_premature_end_of_buffer;
-      return 1;
-    }
+  const size_t size = state->size;
 
-    did_consume = json_skip_whitespace(state);
+  if (json_parse_flags_allow_c_style_comments & state->flags_bitset) {
+    do {
+      if (state->offset == size) {
+        state->error = json_parse_error_premature_end_of_buffer;
+        return 1;
+      }
 
-    if (json_parse_flags_allow_c_style_comments & state->flags_bitset) {
-      //This shoud really be checked on access, not in front of every call
-      if (state->offset == state-> size) {
-	state->error = json_parse_error_premature_end_of_buffer;
+      did_consume = json_skip_whitespace(state);
+
+      // This should really be checked on access, not in front of every call
+      if (state->offset == size) {
+        state->error = json_parse_error_premature_end_of_buffer;
         return 1;
       }
 
       did_consume |= json_skip_c_style_comments(state);
-    }
-  } while (0 != did_consume);
+    } while (0 != did_consume);
+  } else {
+    do {
+      if (state->offset == size) {
+        state->error = json_parse_error_premature_end_of_buffer;
+        return 1;
+      }
 
-  if (state->offset == state-> size) {
+      did_consume = json_skip_whitespace(state);
+    } while (0 != did_consume);
+  }
+
+  if (state->offset == size) {
     state->error = json_parse_error_premature_end_of_buffer;
     return 1;
   }
@@ -199,44 +217,54 @@ static int json_skip_all_skippables(struct json_parse_state_s *state) {
 static int json_get_value_size(struct json_parse_state_s *state,
                                int is_global_object);
 
-static int json_get_string_size(struct json_parse_state_s *state, size_t is_key) {
+static int json_get_string_size(struct json_parse_state_s *state,
+                                size_t is_key) {
+  size_t offset = state->offset;
+  const size_t size = state->size;
   size_t data_size = 0;
-  int is_single_quote = '\'' == state->src[state->offset];
+  const int is_single_quote = '\'' == state->src[offset];
+  const char quote_to_use = is_single_quote ? '\'' : '"';
 
-  if ((json_parse_flags_allow_location_information & state->flags_bitset) != 0 && is_key != 0)
+  if ((json_parse_flags_allow_location_information & state->flags_bitset) !=
+          0 &&
+      is_key != 0) {
     state->dom_size += sizeof(struct json_string_ex_s);
-  else
+  } else {
     state->dom_size += sizeof(struct json_string_s);
+  }
 
-  if ('"' != state->src[state->offset]) {
+  if ('"' != state->src[offset]) {
     // if we are allowed single quoted strings check for that too
     if (!((json_parse_flags_allow_single_quoted_strings &
            state->flags_bitset) &&
           is_single_quote)) {
       state->error = json_parse_error_expected_opening_quote;
+      state->offset = offset;
       return 1;
     }
   }
 
   // skip leading '"' or '\''
-  state->offset++;
+  offset++;
 
-  while (state->offset < state->size && (is_single_quote ? '\'' : '"') != state->src[state->offset]) {
+  while ((offset < size) && (quote_to_use != state->src[offset])) {
     // add space for the character
     data_size++;
 
-    if ('\\' == state->src[state->offset]) {
+    if ('\\' == state->src[offset]) {
       // skip reverse solidus character
-      state->offset++;
+      offset++;
 
-      if (state->offset == state->size) {
-        // string can't terminate here!
+      if (offset == size) {
+        state->error = json_parse_error_premature_end_of_buffer;
+        state->offset = offset;
         return 1;
       }
 
-      switch (state->src[state->offset]) {
+      switch (state->src[offset]) {
       default:
         state->error = json_parse_error_invalid_string_escape_sequence;
+        state->offset = offset;
         return 1;
       case '"':
       case '\\':
@@ -247,19 +275,21 @@ static int json_get_string_size(struct json_parse_state_s *state, size_t is_key)
       case 'r':
       case 't':
         // all valid characters!
-        state->offset++;
+        offset++;
         break;
       case 'u':
-        if (state->offset + 5 < state->size) {
+        if (offset + 5 < size) {
           // invalid escaped unicode sequence!
           state->error = json_parse_error_invalid_string_escape_sequence;
+          state->offset = offset;
           return 1;
-        } else if (!json_is_hexadecimal_digit(state->src[state->offset + 1]) ||
-                   !json_is_hexadecimal_digit(state->src[state->offset + 2]) ||
-                   !json_is_hexadecimal_digit(state->src[state->offset + 3]) ||
-                   !json_is_hexadecimal_digit(state->src[state->offset + 4])) {
+        } else if (!json_is_hexadecimal_digit(state->src[offset + 1]) ||
+                   !json_is_hexadecimal_digit(state->src[offset + 2]) ||
+                   !json_is_hexadecimal_digit(state->src[offset + 3]) ||
+                   !json_is_hexadecimal_digit(state->src[offset + 4])) {
           // escaped unicode sequences must contain 4 hexadecimal digits!
           state->error = json_parse_error_invalid_string_escape_sequence;
+          state->offset = offset;
           return 1;
         }
 
@@ -270,29 +300,32 @@ static int json_get_string_size(struct json_parse_state_s *state, size_t is_key)
         data_size += 5;
         break;
       }
-    } else if (('\r' == state->src[state->offset]) ||
-               ('\n' == state->src[state->offset])) {
+    } else if (('\r' == state->src[offset]) || ('\n' == state->src[offset])) {
       if (!(json_parse_flags_allow_multi_line_strings & state->flags_bitset)) {
         // invalid escaped unicode sequence!
         state->error = json_parse_error_invalid_string_escape_sequence;
+        state->offset = offset;
         return 1;
       }
 
-      state->offset++;
+      offset++;
     } else {
       // skip character (valid part of sequence)
-      state->offset++;
+      offset++;
     }
   }
 
   // skip trailing '"' or '\''
-  state->offset++;
+  offset++;
 
   // add enough space to store the string
   state->data_size += data_size;
 
   // one more byte for null terminator ending the string!
   state->data_size++;
+
+  // update offset
+  state->offset = offset;
 
   return 0;
 }
@@ -308,7 +341,9 @@ static int json_get_key_size(struct json_parse_state_s *state) {
     if ('"' == state->src[state->offset]) {
       // ... if we got a comma, just parse the key as a string as normal
       return json_get_string_size(state, 1);
-    } else if ((json_parse_flags_allow_single_quoted_strings & state->flags_bitset) && ('\'' == state->src[state->offset])) {
+    } else if ((json_parse_flags_allow_single_quoted_strings &
+                state->flags_bitset) &&
+               ('\'' == state->src[state->offset])) {
       // ... if we got a comma, just parse the key as a string as normal
       return json_get_string_size(state, 1);
     } else {
@@ -522,38 +557,35 @@ static int json_get_array_size(struct json_parse_state_s *state) {
 }
 
 static int json_get_number_size(struct json_parse_state_s *state) {
-  size_t initial_offset = state->offset;
+  size_t offset = state->offset;
+  const size_t size = state->size;
   int had_leading_digits = 0;
 
   state->dom_size += sizeof(struct json_number_s);
 
   if ((json_parse_flags_allow_hexadecimal_numbers & state->flags_bitset) &&
-      (state->offset + 1 < state->size) && ('0' == state->src[state->offset]) &&
-      (('x' == state->src[state->offset + 1]) ||
-       ('X' == state->src[state->offset + 1]))) {
+      (offset + 1 < size) && ('0' == state->src[offset]) &&
+      (('x' == state->src[offset + 1]) || ('X' == state->src[offset + 1]))) {
     // skip the leading 0x that identifies a hexadecimal number
-    state->offset += 2;
+    offset += 2;
 
     // consume hexadecimal digits
-    while ((state->offset < state->size) &&
-           (('0' <= state->src[state->offset] &&
-            state->src[state->offset] <= '9') ||
-           ('a' <= state->src[state->offset] &&
-            state->src[state->offset] <= 'f') ||
-          ('A' <= state->src[state->offset] &&
-            state->src[state->offset] <= 'F'))) {
-      state->offset++;
+    while ((offset < size) &&
+           (('0' <= state->src[offset] && state->src[offset] <= '9') ||
+            ('a' <= state->src[offset] && state->src[offset] <= 'f') ||
+            ('A' <= state->src[offset] && state->src[offset] <= 'F'))) {
+      offset++;
     }
   } else {
     int found_sign = 0;
     int inf_or_nan = 0;
 
-    if ((state->offset < state->size) && (
-      ('-' == state->src[state->offset]) ||
-      ((json_parse_flags_allow_leading_plus_sign & state->flags_bitset) &&
-      ('+' == state->src[state->offset])))) {
+    if ((offset < size) &&
+        (('-' == state->src[offset]) ||
+         ((json_parse_flags_allow_leading_plus_sign & state->flags_bitset) &&
+          ('+' == state->src[offset])))) {
       // skip valid leading '-' or '+'
-      state->offset++;
+      offset++;
 
       found_sign = 1;
     }
@@ -564,11 +596,11 @@ static int json_get_number_size(struct json_parse_state_s *state) {
       const char nan[4] = "NaN";
       const size_t nan_strlen = sizeof(nan) - 1;
 
-      if (state->offset + inf_strlen < state->size) {
+      if (offset + inf_strlen < size) {
         int found = 1;
         size_t i;
         for (i = 0; i < inf_strlen; i++) {
-          if (inf[i] != state->src[state->offset + i]) {
+          if (inf[i] != state->src[offset + i]) {
             found = 0;
             break;
           }
@@ -576,17 +608,17 @@ static int json_get_number_size(struct json_parse_state_s *state) {
 
         if (found) {
           // We found our special 'Infinity' keyword!
-          state->offset += inf_strlen;
+          offset += inf_strlen;
 
           inf_or_nan = 1;
         }
       }
 
-      if (state->offset + nan_strlen < state->size) {
+      if (offset + nan_strlen < size) {
         int found = 1;
         size_t i;
         for (i = 0; i < nan_strlen; i++) {
-          if (nan[i] != state->src[state->offset + i]) {
+          if (nan[i] != state->src[offset + i]) {
             found = 0;
             break;
           }
@@ -594,101 +626,101 @@ static int json_get_number_size(struct json_parse_state_s *state) {
 
         if (found) {
           // We found our special 'NaN' keyword!
-          state->offset += nan_strlen;
+          offset += nan_strlen;
 
           inf_or_nan = 1;
         }
       }
     }
 
-    if (found_sign && !inf_or_nan && (state->offset < state->size) &&
-        !('0' <= state->src[state->offset] &&
-          state->src[state->offset] <= '9')) {
+    if (found_sign && !inf_or_nan && (offset < size) &&
+        !('0' <= state->src[offset] && state->src[offset] <= '9')) {
       // check if we are allowing leading '.'
       if (!(json_parse_flags_allow_leading_or_trailing_decimal_point &
             state->flags_bitset) ||
-          ('.' != state->src[state->offset])) {
+          ('.' != state->src[offset])) {
         // a leading '-' must be immediately followed by any digit!
         state->error = json_parse_error_invalid_number_format;
+        state->offset = offset;
         return 1;
       }
     }
 
-    if ((state->offset < state->size) && ('0' == state->src[state->offset])) {
+    if ((offset < size) && ('0' == state->src[offset])) {
       // skip valid '0'
-      state->offset++;
+      offset++;
 
-	  // we need to record whether we had any leading digits for checks later
-	  had_leading_digits = 1;
+      // we need to record whether we had any leading digits for checks later
+      had_leading_digits = 1;
 
-      if ((state->offset < state->size) && ('0' <= state->src[state->offset] &&
-                                            state->src[state->offset] <= '9')) {
+      if ((offset < size) &&
+          ('0' <= state->src[offset] && state->src[offset] <= '9')) {
         // a leading '0' must not be immediately followed by any digit!
         state->error = json_parse_error_invalid_number_format;
+        state->offset = offset;
         return 1;
       }
     }
 
     // the main digits of our number next
-    while ((state->offset < state->size) && ('0' <= state->src[state->offset] &&
-                                             state->src[state->offset] <= '9')) {
-      state->offset++;
+    while ((offset < size) &&
+           ('0' <= state->src[offset] && state->src[offset] <= '9')) {
+      offset++;
 
       // we need to record whether we had any leading digits for checks later
       had_leading_digits = 1;
     }
 
-    if ((state->offset < state->size) && ('.' == state->src[state->offset])) {
-      state->offset++;
+    if ((offset < size) && ('.' == state->src[offset])) {
+      offset++;
 
-      if (!('0' <= state->src[state->offset] &&
-              state->src[state->offset] <= '9')) {
-        if (!(json_parse_flags_allow_leading_or_trailing_decimal_point & state->flags_bitset) ||
-          !had_leading_digits) {
+      if (!('0' <= state->src[offset] && state->src[offset] <= '9')) {
+        if (!(json_parse_flags_allow_leading_or_trailing_decimal_point &
+              state->flags_bitset) ||
+            !had_leading_digits) {
           // a decimal point must be followed by at least one digit
           state->error = json_parse_error_invalid_number_format;
+          state->offset = offset;
           return 1;
         }
       }
 
       // a decimal point can be followed by more digits of course!
-      while ((state->offset < state->size) &&
-             ('0' <= state->src[state->offset] &&
-              state->src[state->offset] <= '9')) {
-        state->offset++;
+      while ((offset < size) &&
+             ('0' <= state->src[offset] && state->src[offset] <= '9')) {
+        offset++;
       }
     }
 
-    if ((state->offset < state->size) &&
-        ('e' == state->src[state->offset] || 'E' == state->src[state->offset])) {
+    if ((offset < size) &&
+        ('e' == state->src[offset] || 'E' == state->src[offset])) {
       // our number has an exponent!
       // skip 'e' or 'E'
-      state->offset++;
+      offset++;
 
-      if ((state->offset < state->size) && ('-' == state->src[state->offset] ||
-                                            '+' == state->src[state->offset])) {
+      if ((offset < size) &&
+          ('-' == state->src[offset] || '+' == state->src[offset])) {
         // skip optional '-' or '+'
-        state->offset++;
+        offset++;
       }
 
       // consume exponent digits
-      while ((state->offset < state->size) &&
-             ('0' <= state->src[state->offset] &&
-              state->src[state->offset] <= '9')) {
-        state->offset++;
+      while ((offset < size) &&
+             ('0' <= state->src[offset] && state->src[offset] <= '9')) {
+        offset++;
       }
     }
   }
 
-  if (state->offset < state->size) {
-    switch (state->src[state->offset]) {
+  if (offset < size) {
+    switch (state->src[offset]) {
     case ' ':
     case '\t':
     case '\r':
     case '\n':
     case '}':
     case ',':
-    case ']':  
+    case ']':
       // all of the above are ok
       break;
     case '=':
@@ -697,14 +729,18 @@ static int json_get_number_size(struct json_parse_state_s *state) {
       }
     default:
       state->error = json_parse_error_invalid_number_format;
+      state->offset = offset;
       return 1;
     }
   }
 
-  state->data_size += state->offset - initial_offset;
+  state->data_size += offset - state->offset;
 
   // one more byte for null terminator ending the number string!
   state->data_size++;
+
+  // update offset
+  state->offset = offset;
 
   return 0;
 }
@@ -727,15 +763,14 @@ static int json_get_value_size(struct json_parse_state_s *state,
     switch (state->src[state->offset]) {
     case '"':
       return json_get_string_size(state, 0);
-	case '\'':
-          if (json_parse_flags_allow_single_quoted_strings &
-              state->flags_bitset) {
-            return json_get_string_size(state, 0);
-		} else {
-			// invalid value!
-			state->error = json_parse_error_invalid_value;
-			return 1;
-		}
+    case '\'':
+      if (json_parse_flags_allow_single_quoted_strings & state->flags_bitset) {
+        return json_get_string_size(state, 0);
+      } else {
+        // invalid value!
+        state->error = json_parse_error_invalid_value;
+        return 1;
+      }
     case '{':
       return json_get_object_size(state, /* is_global_object = */ 0);
     case '[':
@@ -761,7 +796,8 @@ static int json_get_value_size(struct json_parse_state_s *state,
         return 1;
       }
     case '.':
-      if (json_parse_flags_allow_leading_or_trailing_decimal_point & state->flags_bitset) {
+      if (json_parse_flags_allow_leading_or_trailing_decimal_point &
+          state->flags_bitset) {
         return json_get_number_size(state);
       } else {
         // invalid value!
@@ -822,84 +858,90 @@ static void json_parse_value(struct json_parse_state_s *state,
 
 static void json_parse_string(struct json_parse_state_s *state,
                               struct json_string_s *string) {
-  size_t size = 0;
-  int is_single_quote = '\'' == state->src[state->offset];
+  size_t offset = state->offset;
+  const size_t size = state->size;
+  size_t bytes_written = 0;
+  const char quote_to_use = '\'' == state->src[offset] ? '\'' : '"';
 
   string->string = state->data;
 
   // skip leading '"' or '\''
-  state->offset++;
+  offset++;
 
-  while (state->offset < state->size && (is_single_quote ? '\'' : '"') != state->src[state->offset]) {
-    if ('\\' == state->src[state->offset]) {
+  do {
+    if ('\\' == state->src[offset]) {
       // skip the reverse solidus
-      state->offset++;
+      offset++;
 
-      switch (state->src[state->offset++]) {
+      switch (state->src[offset++]) {
       default:
-        return; // we cannot every reach here
+        return; // we cannot ever reach here
       case '"':
-        state->data[size++] = '"';
+        state->data[bytes_written++] = '"';
         break;
       case '\\':
-        state->data[size++] = '\\';
+        state->data[bytes_written++] = '\\';
         break;
       case '/':
-        state->data[size++] = '/';
+        state->data[bytes_written++] = '/';
         break;
       case 'b':
-        state->data[size++] = '\b';
+        state->data[bytes_written++] = '\b';
         break;
       case 'f':
-        state->data[size++] = '\f';
+        state->data[bytes_written++] = '\f';
         break;
       case 'n':
-        state->data[size++] = '\n';
+        state->data[bytes_written++] = '\n';
         break;
       case 'r':
-        state->data[size++] = '\r';
+        state->data[bytes_written++] = '\r';
         break;
       case 't':
-        state->data[size++] = '\t';
+        state->data[bytes_written++] = '\t';
         break;
       case '\r':
-        state->data[size++] = '\r';
+        state->data[bytes_written++] = '\r';
 
         // check if we have a "\r\n" sequence
-        if ('\n' == state->src[state->offset]) {
-          state->data[size++] = '\n';
-          state->offset++;
+        if ('\n' == state->src[offset]) {
+          state->data[bytes_written++] = '\n';
+          offset++;
         }
 
         break;
       case '\n':
-        state->data[size++] = '\n';
+        state->data[bytes_written++] = '\n';
         break;
       }
     } else {
       // copy the character
-      state->data[size++] = state->src[state->offset++];
+      state->data[bytes_written++] = state->src[offset++];
     }
-  }
+  } while (offset < size && (quote_to_use != state->src[offset]));
 
   // skip trailing '"' or '\''
-  state->offset++;
+  offset++;
 
   // record the size of the string
-  string->string_size = size;
+  string->string_size = bytes_written;
 
   // add null terminator to string
-  state->data[size++] = '\0';
+  state->data[bytes_written++] = '\0';
 
   // move data along
-  state->data += size;
+  state->data += bytes_written;
+
+  // update offset
+  state->offset = offset;
 }
 
 static void json_parse_key(struct json_parse_state_s *state,
                            struct json_string_s *string) {
   if (json_parse_flags_allow_unquoted_keys & state->flags_bitset) {
     // if we are allowing unquoted keys, check for quoted anyway...
-    if (('"' == state->src[state->offset]) || ('\'' == state->src[state->offset])) {
+    if (('"' == state->src[state->offset]) ||
+        ('\'' == state->src[state->offset])) {
       // ... if we got a quote, just parse the key as a string as normal
       json_parse_string(state, string);
     } else {
@@ -1147,32 +1189,30 @@ static void json_parse_array(struct json_parse_state_s *state,
 
 static void json_parse_number(struct json_parse_state_s *state,
                               struct json_number_s *number) {
-  size_t size = 0;
-  size_t end = 0;
+  size_t offset = state->offset;
+  const size_t size = state->size;
+  size_t bytes_written = 0;
 
   number->number = state->data;
 
   if (json_parse_flags_allow_hexadecimal_numbers & state->flags_bitset) {
-    if (('0' == state->src[state->offset]) &&
-        (('x' == state->src[state->offset + 1]) ||
-         ('X' == state->src[state->offset + 1]))) {
+    if (('0' == state->src[offset]) &&
+        (('x' == state->src[offset + 1]) || ('X' == state->src[offset + 1]))) {
       // consume hexadecimal digits
-      while ((state->offset < state->size) &&
-             (('0' <= state->src[state->offset] &&
-               state->src[state->offset] <= '9') ||
-              ('a' <= state->src[state->offset] &&
-               state->src[state->offset] <= 'f') ||
-              ('A' <= state->src[state->offset] &&
-               state->src[state->offset] <= 'F') ||
-              ('x' == state->src[state->offset]) ||
-              ('X' == state->src[state->offset]))) {
-        state->data[size++] = state->src[state->offset++];
+      while ((offset < size) &&
+             (('0' <= state->src[offset] && state->src[offset] <= '9') ||
+              ('a' <= state->src[offset] && state->src[offset] <= 'f') ||
+              ('A' <= state->src[offset] && state->src[offset] <= 'F') ||
+              ('x' == state->src[offset]) || ('X' == state->src[offset]))) {
+        state->data[bytes_written++] = state->src[offset++];
       }
     }
   }
 
-  while (state->offset < state->size && end == 0) {
-    switch (state->src[state->offset]) {
+  while (offset < size) {
+    int end = 0;
+
+    switch (state->src[offset]) {
     case '0':
     case '1':
     case '2':
@@ -1188,10 +1228,14 @@ static void json_parse_number(struct json_parse_state_s *state,
     case 'E':
     case '+':
     case '-':
-      state->data[size++] = state->src[state->offset++];
+      state->data[bytes_written++] = state->src[offset++];
       break;
     default:
       end = 1;
+      break;
+    }
+
+    if (0 != end) {
       break;
     }
   }
@@ -1202,33 +1246,35 @@ static void json_parse_number(struct json_parse_state_s *state,
     const char nan[4] = "NaN";
     const size_t nan_strlen = sizeof(nan) - 1;
 
-    if (state->offset + inf_strlen < state->size) {
-      if ('I' == state->src[state->offset]) {
+    if (offset + inf_strlen < size) {
+      if ('I' == state->src[offset]) {
         size_t i;
         // We found our special 'Infinity' keyword!
         for (i = 0; i < inf_strlen; i++) {
-          state->data[size++] = state->src[state->offset++];
+          state->data[bytes_written++] = state->src[offset++];
         }
       }
     }
 
-    if (state->offset + nan_strlen < state->size) {
-      if ('N' == state->src[state->offset]) {
+    if (offset + nan_strlen < size) {
+      if ('N' == state->src[offset]) {
         size_t i;
         // We found our special 'NaN' keyword!
         for (i = 0; i < nan_strlen; i++) {
-          state->data[size++] = state->src[state->offset++];
+          state->data[bytes_written++] = state->src[offset++];
         }
       }
     }
   }
 
   // record the size of the number
-  number->number_size = size;
+  number->number_size = bytes_written;
   // add null terminator to number string
-  state->data[size++] = '\0';
+  state->data[bytes_written++] = '\0';
   // move data along
-  state->data += size;
+  state->data += bytes_written;
+  // update offset
+  state->offset = offset;
 }
 
 static void json_parse_value(struct json_parse_state_s *state,
@@ -1239,27 +1285,29 @@ static void json_parse_value(struct json_parse_state_s *state,
     value->type = json_type_object;
     value->payload = state->dom;
     state->dom += sizeof(struct json_object_s);
-    json_parse_object(state, /* is_global_object = */ 1, (struct json_object_s*)value->payload);
+    json_parse_object(state, /* is_global_object = */ 1,
+                      (struct json_object_s *)value->payload);
   } else {
     switch (state->src[state->offset]) {
     case '"':
-	case '\'':
+    case '\'':
       value->type = json_type_string;
       value->payload = state->dom;
       state->dom += sizeof(struct json_string_s);
-      json_parse_string(state, (struct json_string_s*)value->payload);
+      json_parse_string(state, (struct json_string_s *)value->payload);
       break;
     case '{':
       value->type = json_type_object;
       value->payload = state->dom;
       state->dom += sizeof(struct json_object_s);
-      json_parse_object(state, /* is_global_object = */ 0, (struct json_object_s*)value->payload);
+      json_parse_object(state, /* is_global_object = */ 0,
+                        (struct json_object_s *)value->payload);
       break;
     case '[':
       value->type = json_type_array;
       value->payload = state->dom;
       state->dom += sizeof(struct json_array_s);
-      json_parse_array(state, (struct json_array_s*)value->payload);
+      json_parse_array(state, (struct json_array_s *)value->payload);
       break;
     case '-':
     case '+':
@@ -1273,11 +1321,11 @@ static void json_parse_value(struct json_parse_state_s *state,
     case '7':
     case '8':
     case '9':
-	case '.':
+    case '.':
       value->type = json_type_number;
       value->payload = state->dom;
       state->dom += sizeof(struct json_number_s);
-      json_parse_number(state, (struct json_number_s*)value->payload);
+      json_parse_number(state, (struct json_number_s *)value->payload);
       break;
     default:
       if ((state->offset + 4) <= state->size &&
@@ -1375,7 +1423,7 @@ json_parse_ex(const void *src, size_t src_size, size_t flags_bitset,
 
     if (state.offset != state.size) {
       /* our parsing didn't have an error, but there are characters remaining in
-      * the input that weren't part of the JSON! */
+       * the input that weren't part of the JSON! */
 
       state.error = json_parse_error_unexpected_trailing_characters;
       input_error = 1;
@@ -1440,12 +1488,11 @@ json_parse_ex(const void *src, size_t src_size, size_t flags_bitset,
     state.dom += sizeof(struct json_value_s);
   }
 
-  json_parse_value(
-      &state, /* is_global_object = */ (json_parse_flags_allow_global_object &
-                                        state.flags_bitset),
-      value);
+  json_parse_value(&state, /* is_global_object = */
+                   (json_parse_flags_allow_global_object & state.flags_bitset),
+                   value);
 
-  return (struct json_value_s*)allocation;
+  return (struct json_value_s *)allocation;
 }
 
 struct json_value_s *json_parse(const void *src, size_t src_size) {


### PR DESCRIPTION
I've been using Intel's VTune to look at the code and found some really
dumb performance improvements that I should have spotted long ago:

- The compiler didn't know that the json_parse_state_s* struct that is
  passed to all methods will not be modified outwith the current call tree
  and so it was constantly reloading state->offset and state->size
  members. In the functions where I loop through state->src using the
  offset and size I cache the offset and size into function variables,
  which then means they get kept in registers for the entire run of the
  functions.
- Optimized some branches such that our misprediction rate dropped
  significantly in some of the hot branches.
- In the string parsing functions I support both ' and " as string quotes,
  but I was re-checking which quote to use multiple times which caused
  branch mispredicts. Instead I store the quote to compare against and
  just compare against that.
- In json_skip_all_skippables instead of checking the flags_bitset value
  for whether C style comments were supported on every iteration of the
  loop (the compiler didn't realise flags_bitset wouldn't change!) I check
  it once and branch into two separate loops (one that does C style
  comment handling, one without).
- Reorder the members of json_parse_state_s to group variables together
  that are used together such that they appear in the same cacheline.
- Change some loops that had switch statements within them such that the
  default case of the switch was meant to break out of the switch AND the
  loop, to use a loop-local variable and then check this and break the
  loop after the switch statement. This helped branch mispredicts and also
  the layout of branches to be more sane.