### PR TITLE
Fix Unicode escapes and empty strings parsing

### DIFF
--- a/json.c
+++ b/json.c
@@ -75,7 +75,7 @@ struct json_parse_state_s {
   size_t error;
 };
 
-static unsigned char json_hexadecimal_digit(const char c) {
+static int json_hexadecimal_digit(const char c) {
   if ('0' <= c && c <= '9') {
     return c - '0';
   }
@@ -85,7 +85,7 @@ static unsigned char json_hexadecimal_digit(const char c) {
   if ('A' <= c && c <= 'F') {
     return c - 'A' + 10;
   }
-  return 0x10;
+  return -1;
 }
 
 static int json_hexadecimal_value(const char * c, const unsigned long size, unsigned long * result) {
@@ -94,16 +94,16 @@ static int json_hexadecimal_value(const char * c, const unsigned long size, unsi
   }
 
   const char * p;
-  unsigned char digit;
+  int digit;
 
   *result = 0;
   for (p = c; (unsigned long)(p - c) < size; ++p) {
     *result <<= 4;
     digit = json_hexadecimal_digit(*p);
-    if (digit >= 0x10) {
+    if (digit < 0 || digit > 15) {
       return 0;
     }
-    *result |= digit;
+    *result |= (unsigned char)digit;
   }
   return 1;
 }

--- a/json.c
+++ b/json.c
@@ -324,7 +324,7 @@ static int json_get_string_size(struct json_parse_state_s *state,
           return 1;
         }
      
-		codepoint = 0;
+        codepoint = 0;
         if (0 != json_hexadecimal_value(&src[offset + 1], 4, &codepoint)) {
           // escaped unicode sequences must contain 4 hexadecimal digits!
           state->error = json_parse_error_invalid_string_escape_sequence;
@@ -951,7 +951,7 @@ static void json_parse_string(struct json_parse_state_s *state,
         return; // we cannot ever reach here
       case 'u':
         {
-		  codepoint = 0;
+          codepoint = 0;
           if (0 != json_hexadecimal_value(&src[offset], 4, &codepoint)) {
             return; // this shouldn't happen as the value was already validated
           }
@@ -973,8 +973,8 @@ static void json_parse_string(struct json_parse_state_s *state,
           }
         }
         break;
-	  case '"':
-		data[bytes_written++] = '"';
+      case '"':
+        data[bytes_written++] = '"';
         break;
       case '\\':
         data[bytes_written++] = '\\';

--- a/json.c
+++ b/json.c
@@ -278,7 +278,7 @@ static int json_get_string_size(struct json_parse_state_s *state,
         offset++;
         break;
       case 'u':
-        if (offset + 5 < size) {
+        if (!(offset + 5 < size)) {
           // invalid escaped unicode sequence!
           state->error = json_parse_error_invalid_string_escape_sequence;
           state->offset = offset;
@@ -294,7 +294,7 @@ static int json_get_string_size(struct json_parse_state_s *state,
         }
 
         // valid sequence!
-        state->offset += 5;
+        offset += 5;
 
         // add space for the 5 character sequence too
         data_size += 5;

--- a/json.c
+++ b/json.c
@@ -960,18 +960,18 @@ static void json_parse_string(struct json_parse_state_s *state,
   
           offset += 4;
   
-          if (codepoint <= 0x7f) {
-            data[bytes_written++] = codepoint; // 0xxxxxxx
+          if (codepoint <= 0x7fu) {
+            data[bytes_written++] = (char)codepoint; // 0xxxxxxx
           }
-          else if (codepoint <= 0x7ff) {
-            data[bytes_written++] = 0xc0 | (codepoint >> 6); // 110xxxxx
-            data[bytes_written++] = 0x80 | (codepoint & 0x3f); // 10xxxxxx
+          else if (codepoint <= 0x7ffu) {
+            data[bytes_written++] = (char)(0xc0u | (codepoint >> 6)); // 110xxxxx
+            data[bytes_written++] = (char)(0x80u | (codepoint & 0x3fu)); // 10xxxxxx
           }
           else {
             // we assume the value was validated and thus is within the valid range
-            data[bytes_written++] = 0xe0 | (codepoint >> 12); // 1110xxxx
-            data[bytes_written++] = 0x80 | ((codepoint >> 6) & 0x3f); // 10xxxxxx
-            data[bytes_written++] = 0x80 | (codepoint & 0x3f); // 10xxxxxx
+            data[bytes_written++] = (char)(0xe0u | (codepoint >> 12)); // 1110xxxx
+            data[bytes_written++] = (char)(0x80u | ((codepoint >> 6) & 0x3fu)); // 10xxxxxx
+            data[bytes_written++] = (char)(0x80u | (codepoint & 0x3fu)); // 10xxxxxx
           }
         }
         break;

--- a/json.c
+++ b/json.c
@@ -89,12 +89,12 @@ static int json_hexadecimal_digit(const char c) {
 }
 
 static int json_hexadecimal_value(const char * c, const unsigned long size, unsigned long * result) {
-  if (size > sizeof(unsigned long) * 2) {
-    return -2;
-  }
-
   const char * p;
   int digit;
+
+  if (size > sizeof(unsigned long) * 2) {
+    return 0;
+  }
 
   *result = 0;
   for (p = c; (unsigned long)(p - c) < size; ++p) {

--- a/json.c
+++ b/json.c
@@ -80,6 +80,35 @@ static int json_is_hexadecimal_digit(const char c) {
           ('A' <= c && c <= 'F'));
 }
 
+static int json_hexadecimal_digit(const char c) {
+  if ('0' <= c && c <= '9') {
+    return c - '0';
+  }
+  if ('a' <= c && c <= 'f') {
+    return c - 'a' + 10;
+  }
+  if ('A' <= c && c <= 'F') {
+    return c - 'A' + 10;
+  }
+  return -1;
+}
+
+static int json_hexadecimal_value(const char * c, const int size, unsigned int * result) {
+  if (size > sizeof(unsigned int) * 2) {
+    return -2;
+  }
+  *result = 0;
+  for (const char * p = c; p - c < size; ++p) {
+    *result <<= 4;
+    int digit = json_hexadecimal_digit(*p);
+    if (digit == -1) {
+      return -1;
+    }
+    *result |= digit;
+  }
+  return 0;
+}
+
 static int json_skip_whitespace(struct json_parse_state_s *state) {
   size_t offset = state->offset;
   const size_t size = state->size;
@@ -296,10 +325,10 @@ static int json_get_string_size(struct json_parse_state_s *state,
           state->error = json_parse_error_invalid_string_escape_sequence;
           state->offset = offset;
           return 1;
-        } else if (!json_is_hexadecimal_digit(src[offset + 1]) ||
-                   !json_is_hexadecimal_digit(src[offset + 2]) ||
-                   !json_is_hexadecimal_digit(src[offset + 3]) ||
-                   !json_is_hexadecimal_digit(src[offset + 4])) {
+        }
+     
+        unsigned int codepoint;
+        if (0 != json_hexadecimal_value(&src[offset + 1], 4, &codepoint)) {
           // escaped unicode sequences must contain 4 hexadecimal digits!
           state->error = json_parse_error_invalid_string_escape_sequence;
           state->offset = offset;
@@ -307,10 +336,32 @@ static int json_get_string_size(struct json_parse_state_s *state,
         }
 
         // valid sequence!
-        offset += 5;
+        // see: https://en.wikipedia.org/wiki/UTF-8#Invalid_code_points
+        //      1       7       U + 0000        U + 007F        0xxxxxxx
+        //      2       11      U + 0080        U + 07FF        110xxxxx        10xxxxxx
+        //      3       16      U + 0800        U + FFFF        1110xxxx        10xxxxxx        10xxxxxx
+        //      4       21      U + 10000       U + 10FFFF      11110xxx        10xxxxxx        10xxxxxx        10xxxxxx
+        // Note: the high and low surrogate halves used by UTF-16 (U+D800 through U+DFFF) and code points not encodable by UTF-16 (those after U+10FFFF) are not legal Unicode values, and their UTF-8 encoding must be treated as an invalid byte sequence.
+    
+        if (codepoint <= 0x7f) {
+          offset += 1;
+          data_size += 1;
+        }
+        else if (codepoint <= 0x7ff) {
+          offset += 2;
+          data_size += 2;
+        }
+        else if (codepoint >= 0xd800 && codepoint <= 0xdfff) {
+          state->error = json_parse_error_invalid_string_escape_sequence;
+          state->offset = offset;
+          return 1;
+        }
+        else {
+          offset += 3;
+          data_size += 3;
+        }
+        // codepoints after 0xffff are not supported in json
 
-        // add space for the 5 character sequence too
-        data_size += 5;
         break;
       }
     } else if (('\r' == src[offset]) || ('\n' == src[offset])) {
@@ -892,7 +943,7 @@ static void json_parse_string(struct json_parse_state_s *state,
   // skip leading '"' or '\''
   offset++;
 
-  do {
+  while (quote_to_use != src[offset]) {
     if ('\\' == src[offset]) {
       // skip the reverse solidus
       offset++;
@@ -900,8 +951,32 @@ static void json_parse_string(struct json_parse_state_s *state,
       switch (src[offset++]) {
       default:
         return; // we cannot ever reach here
-      case '"':
-        data[bytes_written++] = '"';
+      case 'u':
+        {
+          unsigned int codepoint;
+          if (0 != json_hexadecimal_value(&src[offset], 4, &codepoint)) {
+            return; // this shouldn't happen as the value was already validated
+          }
+  
+          offset += 4;
+  
+          if (codepoint <= 0x7f) {
+            data[bytes_written++] = codepoint; // 0xxxxxxx
+          }
+          else if (codepoint <= 0x7ff) {
+            data[bytes_written++] = 0xc0 | (codepoint >> 6); // 110xxxxx
+            data[bytes_written++] = 0x80 | (codepoint & 0x3f); // 10xxxxxx
+          }
+          else {
+            // we assume the value was validated and thus is within the valid range
+            data[bytes_written++] = 0xe0 | (codepoint >> 12); // 1110xxxx
+            data[bytes_written++] = 0x80 | ((codepoint >> 6) & 0x3f); // 10xxxxxx
+            data[bytes_written++] = 0x80 | (codepoint & 0x3f); // 10xxxxxx
+          }
+        }
+        break;
+	  case '"':
+		data[bytes_written++] = '"';
         break;
       case '\\':
         data[bytes_written++] = '\\';
@@ -942,7 +1017,7 @@ static void json_parse_string(struct json_parse_state_s *state,
       // copy the character
       data[bytes_written++] = src[offset++];
     }
-  } while (quote_to_use != src[offset]);
+  }
 
   // skip trailing '"' or '\''
   offset++;

--- a/test/main.c
+++ b/test/main.c
@@ -807,4 +807,36 @@ UTEST(object, empty_strings) {
 }
 
 
+UTEST(string, unicode_escape) {
+	const char expected_str[] = "\xEA\x83\x8A" "ABC" "\xC3\x8A" "DEF" "\n";
+	const char payload[] = "[\"\\ua0caABC\\u00caDEF\\u000a\"]";
+	struct json_value_s *value = json_parse(payload, strlen(payload));
+	struct json_array_s *array = 0;
+	struct json_string_s *str = 0;
+
+	ASSERT_TRUE(value);
+	ASSERT_TRUE(value->payload);
+	ASSERT_EQ(json_type_array, value->type);
+
+	array = (struct json_array_s *)value->payload;
+
+	ASSERT_TRUE(array->start);
+	ASSERT_EQ(1, array->length);
+
+	ASSERT_TRUE(array->start->value);
+	ASSERT_TRUE(array->start->value->payload);
+	ASSERT_EQ(json_type_string, array->start->value->type);
+
+	str = (struct json_number_s *)array->start->value->payload;
+
+	ASSERT_TRUE(str->string);
+
+	ASSERT_STREQ(expected_str, str->string);
+	ASSERT_EQ(strlen(expected_str), str->string_size);
+	ASSERT_EQ(strlen(str->string), str->string_size);
+
+	free(value);
+}
+
+
 UTEST_MAIN();

--- a/test/main.c
+++ b/test/main.c
@@ -827,7 +827,7 @@ UTEST(string, unicode_escape) {
 	ASSERT_TRUE(array->start->value->payload);
 	ASSERT_EQ(json_type_string, array->start->value->type);
 
-	str = (struct json_number_s *)array->start->value->payload;
+	str = array->start->value->payload;
 
 	ASSERT_TRUE(str->string);
 

--- a/test/main.c
+++ b/test/main.c
@@ -744,4 +744,67 @@ UTEST(array, missing_closing_bracket) {
   ASSERT_EQ(1, result.error_row_no);
 }
 
+
+UTEST(object, empty_strings) {
+	const char payload[] = "{\"foo\": \"\", \"bar\": \"\"}";
+	struct json_value_s *value = json_parse(payload, strlen(payload));
+	struct json_object_s *object = 0;
+	struct json_object_element_s *el1 = 0;
+	struct json_object_element_s *el2 = 0;
+	struct json_string_s *s1 = 0;
+	struct json_string_s *s2 = 0;
+
+	ASSERT_TRUE(value);
+	ASSERT_TRUE(value->payload);
+	ASSERT_EQ(json_type_object, value->type);
+
+	object = (struct json_object_s *)value->payload;
+
+	ASSERT_EQ(2, object->length);
+
+	el1 = object->start;
+	ASSERT_TRUE(el1);
+	el2 = el1->next;
+	ASSERT_TRUE(el2);
+
+	ASSERT_FALSE(el2->next); // we have only one element
+
+	ASSERT_TRUE(el1->name);
+	ASSERT_TRUE(el1->name->string);
+	ASSERT_STREQ("foo", el1->name->string);
+	ASSERT_EQ(strlen("foo"), el1->name->string_size);
+	ASSERT_EQ(strlen(el1->name->string),
+		el1->name->string_size);
+
+	ASSERT_TRUE(el1->value);
+	ASSERT_EQ(json_type_string, el1->value->type);
+	s1 = el1->value->payload;
+	ASSERT_TRUE(s1);
+	ASSERT_TRUE(s1->string);
+	ASSERT_STREQ("", s1->string);
+	ASSERT_EQ(strlen(""), s1->string_size);
+	ASSERT_EQ(strlen(s1->string),
+		s1->string_size);
+
+	ASSERT_TRUE(el2->name);
+	ASSERT_TRUE(el2->name->string);
+	ASSERT_STREQ("bar", el2->name->string);
+	ASSERT_EQ(strlen("bar"), el2->name->string_size);
+	ASSERT_EQ(strlen(el2->name->string),
+		el2->name->string_size);
+
+	ASSERT_TRUE(el2->value);
+	ASSERT_EQ(json_type_string, el2->value->type);
+	s2 = el2->value->payload;
+	ASSERT_TRUE(s2);
+	ASSERT_TRUE(s2->string);
+	ASSERT_STREQ("", s2->string);
+	ASSERT_EQ(strlen(""), s2->string_size);
+	ASSERT_EQ(strlen(s2->string),
+		s2->string_size);
+
+	free(value);
+}
+
+
 UTEST_MAIN();


### PR DESCRIPTION
The logic was reversed in the code that validates that the Unicode escape sequence ("\uXXXX") is long enough. Also, the wrong offset was pushed forward.