### PR TITLE
Fix buffer overflow in string parsing.

### DIFF
--- a/json.h
+++ b/json.h
@@ -773,6 +773,13 @@ int json_get_string_size(struct json_parse_state_s *state,
     }
   }
 
+  /* If the offset is equal to the size, we had a non-terminated string! */
+  if (offset == size) {
+    state->error = json_parse_error_premature_end_of_buffer;
+    state->offset = offset - 1;
+    return 1;
+  }
+
   /* skip trailing '"' or '\''. */
   offset++;
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -899,6 +899,12 @@ UTEST(helpers, all) {
   free(root);
 }
 
+UTEST(random, overflow) {
+  const char payload[] = "\n\t\t\n\t\t\t\t\"\x00";
+  struct json_value_s *const root = json_parse(payload, sizeof(payload));
+  ASSERT_FALSE(root);
+}
+
 #define assert(x) ASSERT_TRUE(x)
 
 UTEST(generated, readme){


### PR DESCRIPTION
Basically I never checked post string parsing if we hit the end of file,
because if we did it'd mean we didn't actually successfully parse a
string.

Fixes #69.