### PR TITLE
Added a simple custom allocator system

### DIFF
--- a/json.h
+++ b/json.h
@@ -70,6 +70,7 @@ extern "C" {
 
 struct json_value_s;
 struct json_parse_result_s;
+struct json_allocator_s;
 
 enum json_parse_flags_e {
   json_parse_flags_default = 0,
@@ -144,6 +145,16 @@ enum json_parse_flags_e {
        json_parse_flags_allow_inf_and_nan |
        json_parse_flags_allow_multi_line_strings)
 };
+
+/* a Define for the allocate memory function pointer. */
+#define JSON_ALLOC_FUNC(name) void *name(const size_t size, void *user_data)
+/* a Function pointer for allocating a block of memory */
+typedef JSON_ALLOC_FUNC(json_alloc_func_t);
+
+/* a Define for the free memory function pointer. */
+#define JSON_FREE_FUNC(name) void name(void *base, void *user_data)
+/* a Function pointer for freeing a block of memory */
+typedef JSON_FREE_FUNC(json_free_func_t);
 
 /* Parse a JSON text file, returning a pointer to the root of the JSON
  * structure. json_parse performs 1 call to malloc for the entire encoding.
@@ -337,6 +348,18 @@ typedef struct json_value_ex_s {
   size_t row_no;
 
 } json_value_ex_t;
+
+/* a JSON Allocator function table. */
+typedef struct json_allocator_s {
+    /* Allocate function pointer. */
+    json_alloc_func_t *alloc;
+    /* Free function pointer. */
+    json_free_func_t *free;
+    /* Custom user data pointer. */
+    void *user_data;
+    /* Padding to align struct. */
+    uintptr_t padding;
+} json_allocator_t;
 
 /* a parsing error code. */
 enum json_parse_error_e {

--- a/json.h
+++ b/json.h
@@ -394,7 +394,7 @@ enum json_parse_error_e {
   /* string was malformed! */
   json_parse_error_invalid_string,
 
-  /* a call to malloc, or a user provider allocator, failed. */
+  /* a call to default allocator (malloc), or a user provider allocator, failed. */
   json_parse_error_allocator_failed,
 
   /* the JSON input had unexpected trailing characters that weren't part of the.

--- a/json.h
+++ b/json.h
@@ -496,7 +496,28 @@ typedef struct json_parse_result_s {
 #define JSON_MAX_RECURSION 1000
 #endif
 
+json_weak JSON_ALLOC_FUNC(json_default_alloc) {
+    if (0 == size) {
+        return json_null;
+    }
+    return malloc(size);
+}
+
+json_weak JSON_FREE_FUNC(json_default_free) {
+    if (json_null == base) {
+        return;
+    }
+    free(base);
+}
+
+static const struct json_allocator_s json_default_allocator = {
+    .alloc = json_default_alloc,
+    .free = json_default_free,
+    .user_data = json_null,
+};
+
 struct json_parse_state_s {
+  struct json_allocator_s allocator;
   const char *src;
   size_t size;
   size_t offset;
@@ -511,6 +532,13 @@ struct json_parse_state_s {
   size_t error;
   size_t recursion;
 };
+
+json_weak struct json_allocator_s json_create_allocator(struct json_allocator_s *custom_allocator) {
+  if (json_null == custom_allocator || json_null == custom_allocator->alloc || json_null == custom_allocator->free) {
+    return json_default_allocator;
+  }
+  return *custom_allocator;
+}
 
 json_weak int json_hexadecimal_digit(const char c);
 int json_hexadecimal_digit(const char c) {


### PR DESCRIPTION
I added a simple, but powerful custom allocator scheme to your library, that fully replaces all malloc/free calls - but still uses malloc as its default allocator, when not overridden by the user.

In addition i added **json_write_minified_ex**() and  **json_write_pretty_ex**(), to support a custom allocator in there as well.

I would really appreciate it, if you could merge that into your master branch. Thanks!