### PR TITLE
Fix JSON5 single-digit ASan read in number parser

### DIFF
--- a/json.h
+++ b/json.h
@@ -1921,7 +1921,7 @@ void json_parse_number(struct json_parse_state_s *state,
   number->number = data;
 
   if (json_parse_flags_allow_hexadecimal_numbers & flags_bitset) {
-    if (('0' == src[offset]) &&
+    if ((offset + 1 < size) && ('0' == src[offset]) &&
         (('x' == src[offset + 1]) || ('X' == src[offset + 1]))) {
       /* consume hexadecimal digits. */
       while ((offset < size) &&

--- a/test/test_shared.h
+++ b/test/test_shared.h
@@ -1163,6 +1163,33 @@ JSON_TEST(allow_hexadecimal_numbers, uppercase_x_all_possible_digits) {
   free(value);
 }
 
+JSON_TEST(allow_hexadecimal_numbers, zero_json5) {
+  unsigned char *payload = UTEST_PTR_CAST(unsigned char *, malloc(1));
+  const size_t flags = json_parse_flags_allow_hexadecimal_numbers |
+                       json_parse_flags_allow_json5;
+  struct json_value_s *value = UTEST_NULL;
+  struct json_number_s *number = UTEST_NULL;
+
+  ASSERT_TRUE(payload);
+
+  payload[0] = '0';
+
+  value = json_parse_ex(payload, 1, flags, UTEST_NULL, UTEST_NULL, UTEST_NULL);
+
+  ASSERT_TRUE(value);
+  ASSERT_TRUE(value->payload);
+  ASSERT_EQ(json_type_number, value->type);
+
+  number = UTEST_PTR_CAST(struct json_number_s *, value->payload);
+
+  ASSERT_TRUE(number->number);
+  ASSERT_STREQ("0", number->number);
+  ASSERT_EQ(1u, number->number_size);
+
+  free(value);
+  free(payload);
+}
+
 JSON_TEST(allow_hexadecimal_numbers, bad_hexadecimal_char) {
   const char payload[] = "{\"foo\" : 0xA012aBbDEF8976cCdef453g}";
   struct json_parse_result_s result;


### PR DESCRIPTION
## Summary
- Guard the hexadecimal-number lookahead in `json_parse_number()` so a one-byte numeric input does not read past the buffer.
- Add a regression test using an exact 1-byte heap payload (`"0"`) with JSON5/hex-number flags, matching the ASan report.

## Testing
- `ctest --test-dir build --output-on-failure`

---

🧙 Conjured by AI via [pi.dev](https://pi.dev/) using gpt-5.5