### PR TITLE
Fix malformed NaN and Infinity continuations

### DIFF
--- a/json.h
+++ b/json.h
@@ -1253,28 +1253,9 @@ int json_get_number_size(struct json_parse_state_s *state) {
       }
 
       if (inf_or_nan) {
-        if (offset < size) {
-          switch (src[offset]) {
-          default:
-            break;
-          case '0':
-          case '1':
-          case '2':
-          case '3':
-          case '4':
-          case '5':
-          case '6':
-          case '7':
-          case '8':
-          case '9':
-          case 'e':
-          case 'E':
-            /* cannot follow an inf or nan with digits! */
-            state->error = json_parse_error_invalid_number_format;
-            state->offset = offset;
-            return 1;
-          }
-        }
+        /* Infinity and NaN are complete values. Validate the next character as
+         * a number terminator instead of parsing a numeric continuation. */
+        goto number_parsed;
       }
     }
 
@@ -1359,6 +1340,7 @@ int json_get_number_size(struct json_parse_state_s *state) {
     }
   }
 
+number_parsed:
   if (offset < size) {
     switch (src[offset]) {
     case ' ':

--- a/test/test_shared.h
+++ b/test/test_shared.h
@@ -1462,6 +1462,34 @@ JSON_TEST(allow_inf_and_nan, NaNWithLeadingSign) {
   free(value);
 }
 
+JSON_TEST(allow_inf_and_nan, rejects_NaN_decimal_continuation) {
+  const char payload[] = "{\"key\":NaN.1}";
+  struct json_parse_result_s result;
+  struct json_value_s *value =
+      json_parse_ex(payload, strlen(payload), json_parse_flags_allow_json5,
+                    UTEST_NULL, UTEST_NULL, &result);
+
+  ASSERT_FALSE(value);
+  ASSERT_EQ(json_parse_error_invalid_number_format, result.error);
+  ASSERT_EQ(10u, result.error_offset);
+  ASSERT_EQ(1u, result.error_line_no);
+  ASSERT_EQ(10u, result.error_row_no);
+}
+
+JSON_TEST(allow_inf_and_nan, rejects_Infinity_decimal_continuation) {
+  const char payload[] = "{\"key\":Infinity.1}";
+  struct json_parse_result_s result;
+  struct json_value_s *value =
+      json_parse_ex(payload, strlen(payload), json_parse_flags_allow_json5,
+                    UTEST_NULL, UTEST_NULL, &result);
+
+  ASSERT_FALSE(value);
+  ASSERT_EQ(json_parse_error_invalid_number_format, result.error);
+  ASSERT_EQ(15u, result.error_offset);
+  ASSERT_EQ(1u, result.error_line_no);
+  ASSERT_EQ(15u, result.error_row_no);
+}
+
 JSON_TEST(allow_inf_and_nan, forgot_to_specify_flag_Infinity) {
   const char payload[] = "{\"foo\" : Infinity}";
   struct json_parse_result_s result;


### PR DESCRIPTION
Fixes #125.

`NaN` and `Infinity` are complete numeric values when the JSON5 extension is enabled. After recognising either token, validate the following character using the normal number-terminator rules rather than continuing through decimal/exponent parsing.

Adds regressions for `{"key":NaN.1}` and `{"key":Infinity.1}`.

Tests: `ctest --test-dir /tmp/jsonh-build-gcc --output-on-failure`; ASan repro for issue #125.

---

🧙 Conjured by AI via [pi.dev](https://pi.dev/) using gpt-5.6-terra