### PR TITLE
Add allocator callbacks to JSON write functions

### DIFF
--- a/json.h
+++ b/json.h
@@ -182,6 +182,18 @@ json_extract_value_ex(const struct json_value_s *value,
 json_weak void *json_write_minified(const struct json_value_s *value,
                                     size_t *out_size);
 
+/* Write out a minified JSON utf-8 string using custom allocation callbacks.
+ * json_write_minified_ex performs 1 call to alloc_func_ptr for the entire
+ * encoding. If the encoding fails after allocation, free_func_ptr is called.
+ * If alloc_func_ptr or free_func_ptr is null then malloc or free is used,
+ * respectively. user_data is passed as the first argument to either callback.
+ * The out_size parameter is optional as the utf-8 string is null terminated. */
+json_weak void *
+json_write_minified_ex(const struct json_value_s *value,
+                       void *(*alloc_func_ptr)(void *user_data, size_t size),
+                       void (*free_func_ptr)(void *user_data, void *ptr),
+                       void *user_data, size_t *out_size);
+
 /* Write out a pretty JSON utf-8 string. This string is encoded such that the
  * resultant JSON is pretty in that it is easily human readable. The indent and
  * newline parameters allow a user to specify what kind of indentation and
@@ -194,6 +206,20 @@ json_weak void *json_write_minified(const struct json_value_s *value,
 json_weak void *json_write_pretty(const struct json_value_s *value,
                                   const char *indent, const char *newline,
                                   size_t *out_size);
+
+/* Write out a pretty JSON utf-8 string using custom allocation callbacks.
+ * The indent and newline parameters behave as in json_write_pretty.
+ * json_write_pretty_ex performs 1 call to alloc_func_ptr for the entire
+ * encoding. If the encoding fails after allocation, free_func_ptr is called.
+ * If alloc_func_ptr or free_func_ptr is null then malloc or free is used,
+ * respectively. user_data is passed as the first argument to either callback.
+ * The out_size parameter is optional as the utf-8 string is null terminated. */
+json_weak void *
+json_write_pretty_ex(const struct json_value_s *value, const char *indent,
+                     const char *newline,
+                     void *(*alloc_func_ptr)(void *user_data, size_t size),
+                     void (*free_func_ptr)(void *user_data, void *ptr),
+                     void *user_data, size_t *out_size);
 
 /* Reinterpret a JSON value as a string. Returns null is the value was not a
  * string. */
@@ -3087,6 +3113,15 @@ char *json_write_minified_value(const struct json_value_s *value, char *data) {
 }
 
 void *json_write_minified(const struct json_value_s *value, size_t *out_size) {
+  return json_write_minified_ex(value, json_null, json_null, json_null,
+                                out_size);
+}
+
+void *json_write_minified_ex(const struct json_value_s *value,
+                             void *(*alloc_func_ptr)(void *user_data,
+                                                     size_t size),
+                             void (*free_func_ptr)(void *user_data, void *ptr),
+                             void *user_data, size_t *out_size) {
   size_t size = 0;
   char *data = json_null;
   char *data_end = json_null;
@@ -3102,10 +3137,14 @@ void *json_write_minified(const struct json_value_s *value, size_t *out_size) {
 
   size += 1; /* for the '\0' null terminating character. */
 
-  data = (char *)malloc(size);
+  if (json_null == alloc_func_ptr) {
+    data = (char *)malloc(size);
+  } else {
+    data = (char *)alloc_func_ptr(user_data, size);
+  }
 
   if (json_null == data) {
-    /* malloc failed! */
+    /* allocation failed! */
     return json_null;
   }
 
@@ -3113,7 +3152,11 @@ void *json_write_minified(const struct json_value_s *value, size_t *out_size) {
 
   if (json_null == data_end) {
     /* bad chi occurred! */
-    free(data);
+    if (json_null == free_func_ptr) {
+      free(data);
+    } else {
+      free_func_ptr(user_data, data);
+    }
     return json_null;
   }
 
@@ -3430,6 +3473,16 @@ char *json_write_pretty_value(const struct json_value_s *value, size_t depth,
 
 void *json_write_pretty(const struct json_value_s *value, const char *indent,
                         const char *newline, size_t *out_size) {
+  return json_write_pretty_ex(value, indent, newline, json_null, json_null,
+                              json_null, out_size);
+}
+
+void *json_write_pretty_ex(const struct json_value_s *value, const char *indent,
+                           const char *newline,
+                           void *(*alloc_func_ptr)(void *user_data,
+                                                   size_t size),
+                           void (*free_func_ptr)(void *user_data, void *ptr),
+                           void *user_data, size_t *out_size) {
   size_t size = 0;
   size_t indent_size = 0;
   size_t newline_size = 0;
@@ -3464,10 +3517,14 @@ void *json_write_pretty(const struct json_value_s *value, const char *indent,
 
   size += 1; /* for the '\0' null terminating character. */
 
-  data = (char *)malloc(size);
+  if (json_null == alloc_func_ptr) {
+    data = (char *)malloc(size);
+  } else {
+    data = (char *)alloc_func_ptr(user_data, size);
+  }
 
   if (json_null == data) {
-    /* malloc failed! */
+    /* allocation failed! */
     return json_null;
   }
 
@@ -3475,7 +3532,11 @@ void *json_write_pretty(const struct json_value_s *value, const char *indent,
 
   if (json_null == data_end) {
     /* bad chi occurred! */
-    free(data);
+    if (json_null == free_func_ptr) {
+      free(data);
+    } else {
+      free_func_ptr(user_data, data);
+    }
     return json_null;
   }
 

--- a/test/test_shared.h
+++ b/test/test_shared.h
@@ -109,6 +109,34 @@ static void *json_test_allocator_user_data(void *user_data, size_t size) {
   return user_data;
 }
 
+struct json_test_write_allocator_s {
+  struct json_value_s *value;
+  size_t allocations;
+  size_t frees;
+  size_t invalidate_value;
+};
+
+static void *json_test_write_allocator_alloc(void *user_data, size_t size) {
+  struct json_test_write_allocator_s *state =
+      UTEST_PTR_CAST(struct json_test_write_allocator_s *, user_data);
+  void *allocation = malloc(size);
+
+  ++state->allocations;
+  if (state->invalidate_value) {
+    state->value->type = UTEST_CAST(size_t, -1);
+  }
+
+  return allocation;
+}
+
+static void json_test_write_allocator_free(void *user_data, void *ptr) {
+  struct json_test_write_allocator_s *state =
+      UTEST_PTR_CAST(struct json_test_write_allocator_s *, user_data);
+
+  ++state->frees;
+  free(ptr);
+}
+
 JSON_TEST(allocator, malloc) {
 
   const char payload[] = "{}";
@@ -177,6 +205,76 @@ JSON_TEST(allocator, user_data) {
 
   ASSERT_FALSE(object->start);
   ASSERT_EQ(0u, object->length);
+}
+
+JSON_TEST(allocator, write_minified) {
+  struct json_value_s value;
+  struct json_test_write_allocator_s state;
+  void *json;
+  size_t size = 0;
+
+  value.payload = UTEST_NULL;
+  value.type = json_type_null;
+  state.value = &value;
+  state.allocations = 0;
+  state.frees = 0;
+  state.invalidate_value = 0;
+
+  json = json_write_minified_ex(&value, &json_test_write_allocator_alloc,
+                                &json_test_write_allocator_free, &state, &size);
+
+  ASSERT_TRUE(json);
+  ASSERT_STREQ("null", UTEST_CAST(char *, json));
+  ASSERT_EQ(5u, size);
+  ASSERT_EQ(1u, state.allocations);
+  ASSERT_EQ(0u, state.frees);
+
+  json_test_write_allocator_free(&state, json);
+
+  value.type = json_type_null;
+  state.invalidate_value = 1;
+  json = json_write_minified_ex(&value, &json_test_write_allocator_alloc,
+                                &json_test_write_allocator_free, &state, &size);
+
+  ASSERT_FALSE(json);
+  ASSERT_EQ(2u, state.allocations);
+  ASSERT_EQ(2u, state.frees);
+}
+
+JSON_TEST(allocator, write_pretty) {
+  struct json_value_s value;
+  struct json_test_write_allocator_s state;
+  void *json;
+  size_t size = 0;
+
+  value.payload = UTEST_NULL;
+  value.type = json_type_null;
+  state.value = &value;
+  state.allocations = 0;
+  state.frees = 0;
+  state.invalidate_value = 0;
+
+  json = json_write_pretty_ex(&value, UTEST_NULL, UTEST_NULL,
+                              &json_test_write_allocator_alloc,
+                              &json_test_write_allocator_free, &state, &size);
+
+  ASSERT_TRUE(json);
+  ASSERT_STREQ("null", UTEST_CAST(char *, json));
+  ASSERT_EQ(5u, size);
+  ASSERT_EQ(1u, state.allocations);
+  ASSERT_EQ(0u, state.frees);
+
+  json_test_write_allocator_free(&state, json);
+
+  value.type = json_type_null;
+  state.invalidate_value = 1;
+  json = json_write_pretty_ex(&value, UTEST_NULL, UTEST_NULL,
+                              &json_test_write_allocator_alloc,
+                              &json_test_write_allocator_free, &state, &size);
+
+  ASSERT_FALSE(json);
+  ASSERT_EQ(2u, state.allocations);
+  ASSERT_EQ(2u, state.frees);
 }
 
 JSON_TEST(allow_c_style_comments, single_line) {


### PR DESCRIPTION
## Summary

- add `json_write_minified_ex` and `json_write_pretty_ex` with explicit allocation, free, and user-data arguments
- keep the existing write APIs unchanged and have them use the new extended functions with the default `malloc`/`free` behavior
- use the matching free callback if writing fails after allocation
- test custom allocation, user-data forwarding, successful writes, and failure cleanup

This follows the maintainer feedback on and supersedes #110 without introducing an allocator struct or changing the existing parse/extract APIs.

Closes #110.

## Testing

- `cmake -S test -B /tmp/json-h-build -G Ninja -DBUILD_TESTING=ON`
- `cmake --build /tmp/json-h-build --parallel 4`
- `ctest --test-dir /tmp/json-h-build --output-on-failure` (4/4 passed, including AddressSanitizer, UndefinedBehaviorSanitizer, and ThreadSanitizer builds)

---

🧙 Conjured by AI via [pi.dev](https://pi.dev/) using gpt-5.6-sol