### PR TITLE
Keep the number's null terminator when extracting

### DIFF
--- a/json.h
+++ b/json.h
@@ -2253,7 +2253,8 @@ struct json_extract_result_s
 json_extract_get_number_size(const struct json_number_s *const number) {
   struct json_extract_result_s result;
   result.dom_size = sizeof(struct json_number_s);
-  result.data_size = number->number_size;
+  /* one more byte for the null terminator the parser guarantees */
+  result.data_size = number->number_size + 1;
   return result;
 }
 
@@ -2380,8 +2381,9 @@ void json_extract_copy_value(struct json_extract_state_s *const state,
     state->dom += sizeof(struct json_number_s);
 
     memcpy(state->data, number->number, number->number_size);
+    state->data[number->number_size] = '\0';
     number->number = state->data;
-    state->data += number->number_size;
+    state->data += number->number_size + 1;
   } else if (json_type_object == value->type) {
     struct json_object_element_s *element;
     size_t i;

--- a/test/test_shared.h
+++ b/test/test_shared.h
@@ -3690,6 +3690,28 @@ JSON_TEST(extract, all) {
   free(extract);
 }
 
+JSON_TEST(extract, number_is_null_terminated) {
+  const char payload[] = "123";
+  struct json_value_s *value = json_parse(payload, strlen(payload));
+  struct json_value_s *extract = UTEST_NULL;
+  struct json_number_s *number = UTEST_NULL;
+
+  ASSERT_TRUE(value);
+
+  extract = json_extract_value(value);
+  free(value);
+
+  ASSERT_TRUE(extract);
+
+  number = json_value_as_number(extract);
+  ASSERT_TRUE(number);
+  ASSERT_EQ(strlen("123"), number->number_size);
+  ASSERT_EQ('\0', number->number[number->number_size]);
+  ASSERT_STREQ("123", number->number);
+
+  free(extract);
+}
+
 JSON_TEST(extract, empty_object_write_minified) {
   const char payload[] = "{}";
   struct json_value_s *value = json_parse(payload, strlen(payload));


### PR DESCRIPTION
An extracted number is not NUL-terminated, so reading it as a C string runs past the allocation.

The parser reserves the byte deliberately — `json.h:1398`:

```c
/* one more byte for null terminator ending the number string! */
state->data_size++;
```

Extraction does not. `json_extract_get_number_size` (`json.h:2255`) sizes the copy at
`number_size`, and the copy loop (`json.h:2382`) advances by the same amount, so the next value's
data starts where the terminator should be. The string helpers reserve it in both places
(`json.h:2263`, `json.h:2374`, `json.h:2414`); numbers are the only data copy that doesn't.

```c
/* json_extract_get_number_size */
result.data_size = number->number_size;          /* no + 1 */

/* json_extract_get_string_size */
result.data_size = string->string_size + 1;
```

### Reproduction

```c
struct json_value_s *root = json_parse("123", 3);
struct json_number_s *n = (struct json_number_s *)root->payload;
/* n->number[n->number_size] == '\0' here, as the parser promises */

struct json_value_s *ex = json_extract_value(root);
struct json_number_s *n2 = (struct json_number_s *)ex->payload;
atoi(n2->number);                                 /* reads past the buffer */
```

`gcc -fsanitize=address,undefined`:

```
parsed    number_size=3 terminator=0
extracted number_size=3, reading number[number_size]...
==982974==ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1 at 0x504000000073 thread T0
0x504000000073 is located 0 bytes after 35-byte region [0x504000000050,0x504000000073)
```

After the change: `extracted terminator=0  atoi=123`, clean under ASAN.

`number` is documented at `json.h:292` as "ASCII string containing representation of the number",
so `atoi`/`atof`/`strlen`/`%s` on it is the intended use. The library's own round trip
(`extract` then `json_write_minified`) does not trip it, because `json_write_number` reads by
`number_size` — this only bites a consumer that treats the field as the C string it is documented
to be.

### Why the tests miss it

`json_extract_value_ex`, `json_extract_get_number_size` and `json_extract_copy_value` have zero
occurrences across `test/`. `json_extract_value` (`json.h:2237`) hard-codes
`alloc_func_ptr = json_null`, so the `_ex` entry point is only ever reached through that one
pre-set path, and the five existing extract tests stop at empty objects and arrays.

### Change

Write the terminator explicitly rather than copying `number_size + 1` bytes, so a caller-built DOM
whose number happens not to be terminated is not read past either:

```c
memcpy(state->data, number->number, number->number_size);
state->data[number->number_size] = '\0';
number->number = state->data;
state->data += number->number_size + 1;
```

One test added next to the other extract tests. Verified red/green by reverting only `json.h` and
keeping the test — ASAN then fires inside the new case.

Suites built by hand with `-fsanitize=address,undefined` (no cmake here; `generated.h` reproduced
from the README's ```c blocks the way `test/CMakeLists.txt` does): C **546 passed**, C++17
**546 passed**, both before and after apart from the three new cases. A differential run of 5,000
random documents through parse → extract → `json_write_minified` gives identical output.

---

Disclosure: prepared with AI assistance; I verified the ASAN reproduction, the red/green and both
suite runs myself.
